### PR TITLE
feat: add ORM Model

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,24 +1,24 @@
 import Promise from 'bluebird';
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { addResolversToSchema } from '@graphql-tools/schema';
 import { Knex } from 'knex';
 import { Pool as PgPool } from 'pg';
 import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
 import { GqlEntityController } from './graphql/controller';
 import { BaseProvider, StarknetProvider, BlockNotFoundError } from './providers';
-
 import { createLogger, Logger, LogLevel } from './utils/logger';
+import { getContractsFromConfig } from './utils/checkpoint';
 import { createKnex } from './knex';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
 import { createPgPool } from './pg';
+import { register } from './register';
 import {
   ContractSourceConfig,
   CheckpointConfig,
   CheckpointOptions,
   CheckpointWriters
 } from './types';
-import { getContractsFromConfig } from './utils/checkpoint';
 import { CheckpointRecord, CheckpointsStore, MetadataId } from './stores/checkpoints';
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 
 const REFRESH_INTERVAL = 7000;
 
@@ -82,6 +82,8 @@ export default class Checkpoint {
 
     this.knex = createKnex(dbConnection);
     this.dbConnection = dbConnection;
+
+    register.setKnex(this.knex);
   }
 
   public getBaseContext() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import Checkpoint from './checkpoint';
 export { LogLevel } from './utils/logger';
 export { AsyncMySqlPool } from './mysql';
 export { createGetLoader } from './graphql';
+export { Model } from './orm';
 export * from './types';
 
 export default Checkpoint;

--- a/src/orm/index.ts
+++ b/src/orm/index.ts
@@ -1,0 +1,1 @@
+export { default as Model } from './model';

--- a/src/orm/model.ts
+++ b/src/orm/model.ts
@@ -1,0 +1,65 @@
+import { register } from '../register';
+
+export default class Model {
+  private tableName: string;
+  private values = new Map<string, any>();
+  private valuesImplicitlySet = new Set<string>();
+  private exists = false;
+
+  constructor(tableName: string) {
+    this.tableName = tableName;
+  }
+
+  private async _update() {
+    const diff = Object.fromEntries(
+      [...this.values.entries()].filter(([key]) => this.valuesImplicitlySet.has(key))
+    );
+
+    return register.getKnex().table(this.tableName).update(diff).where('id', this.get('id'));
+  }
+
+  private async _insert() {
+    const entity = Object.fromEntries(this.values.entries());
+
+    return register.getKnex().table(this.tableName).insert(entity);
+  }
+
+  private async _delete() {
+    return register.getKnex().table(this.tableName).where('id', this.get('id')).delete();
+  }
+
+  setExists() {
+    this.exists = true;
+  }
+
+  initialSet(key: string, value: any) {
+    this.values.set(key, value);
+  }
+
+  get(key: string): any {
+    return this.values.get(key) || null;
+  }
+
+  set(key: string, value: any) {
+    this.values.set(key, value);
+    this.valuesImplicitlySet.add(key);
+  }
+
+  static async loadEntity(tableName: string, id: string): Promise<Record<string, any> | null> {
+    const knex = register.getKnex();
+
+    const entity = await knex.table(tableName).select('*').where('id', id).first();
+    if (!entity) return null;
+
+    return entity;
+  }
+
+  async save() {
+    if (this.exists) return this._update();
+    return this._insert();
+  }
+
+  async delete() {
+    if (this.exists) this._delete();
+  }
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+function createRegister() {
+  let knexInstance: Knex | null = null;
+
+  return {
+    getKnex() {
+      if (!knexInstance) {
+        throw new Error('Knex is not initialized yet.');
+      }
+
+      return knexInstance;
+    },
+    setKnex(knex: Knex) {
+      knexInstance = knex;
+    }
+  };
+}
+
+export const register = createRegister();


### PR DESCRIPTION
## Summary

Depends on https://github.com/snapshot-labs/checkpoint/pull/212

This PR adds simple Model class that will be used as base for all generated models from schema.

What is missing:
 - codegen to generate models from  GraphQL schemas (with this we probably could start make it public).
 - transactions - all writes from writers should be batched into database transaction, together with call that updates current blockNumber so database stays consistent
 - rollback support - with all requests going through ORM we can store data in DB that will allow us to revert inserts/update/deletes in case of rollbacks.
 
 ## Test plan
 
 - Run this code: https://github.com/snapshot-labs/sx-api/compare/sekhmet/orm?expand=1
 - Run `users` GraphQL query to make sure it works.
