### PR TITLE
feat: add nocase support for contains string/text queries

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -351,6 +351,8 @@ export class GqlEntityController {
       ) {
         whereInputConfig.fields[`${field.name}_contains`] = { type: GraphQLString };
         whereInputConfig.fields[`${field.name}_not_contains`] = { type: GraphQLString };
+        whereInputConfig.fields[`${field.name}_contains_nocase`] = { type: GraphQLString };
+        whereInputConfig.fields[`${field.name}_not_contains_nocase`] = { type: GraphQLString };
       }
 
       if ((nonNullFieldType as GraphQLScalarType).name !== 'Text') {

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -345,7 +345,10 @@ export class GqlEntityController {
         whereInputConfig.fields[`${field.name}_lte`] = { type: nonNullFieldType };
       }
 
-      if (nonNullFieldType === GraphQLString) {
+      if (
+        nonNullFieldType === GraphQLString ||
+        (nonNullFieldType as GraphQLScalarType).name === 'Text'
+      ) {
         whereInputConfig.fields[`${field.name}_contains`] = { type: GraphQLString };
         whereInputConfig.fields[`${field.name}_not_contains`] = { type: GraphQLString };
       }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -56,8 +56,12 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
         query = query.where(w[0].slice(0, -4), '<=', w[1]);
       } else if (w[0].endsWith('_not_contains')) {
         query = query.not.whereLike(w[0].slice(0, -13), `%${w[1]}%`);
+      } else if (w[0].endsWith('_not_contains_nocase')) {
+        query = query.not.whereILike(w[0].slice(0, -20), `%${w[1]}%`);
       } else if (w[0].endsWith('_contains')) {
         query = query.whereLike(w[0].slice(0, -9), `%${w[1]}%`);
+      } else if (w[0].endsWith('_contains_nocase')) {
+        query = query.whereILike(w[0].slice(0, -16), `%${w[1]}%`);
       } else if (w[0].endsWith('_not_in')) {
         query = query.not.whereIn(w[0].slice(0, -7), w[1]);
       } else if (w[0].endsWith('_in')) {

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -49,6 +49,8 @@ input WhereVote {
   id_not_in: [Int]
   name_contains: String
   name_not_contains: String
+  name_contains_nocase: String
+  name_not_contains_nocase: String
   name: String
   name_not: String
   name_in: [String]


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/215

This PR enables `contains` and `not_contains` filters support for Text types and enables `_nocase` variant for those filters for `String` and `Text`.

## Test plan

Run query like this:

```gql
{
  proposals(where: {title_contains_nocase: "some"}) {
    id
    title
  }
}
```