### PR TITLE
feat: add additional checks if there are no events in the block

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -280,7 +280,7 @@ export default class Checkpoint {
         } catch (err) {
           this.log.error({ blockNumber: blockNum, err }, 'error occured during pool processing');
         }
-      } else {
+      } else if (!(err instanceof BlockNotFoundError)) {
         this.log.error({ blockNumber: blockNum, err }, 'error occured during block processing');
       }
 

--- a/src/providers/starknet/utils.ts
+++ b/src/providers/starknet/utils.ts
@@ -91,6 +91,7 @@ export function createResponseValidator({ maxRetries }: { maxRetries: number }) 
       return true;
     }
 
+    retryCounter++;
     return false;
   };
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/checkpoint-labs/checkpoint/issues/185

This is a workaround for issue that occurs when requesting block and events data from two different nodes, which might result in events being empty, due to second node not knowing about that block yet.

With this workaround empty events response will be reject, unless it shows up as such for 3 consecutive ticks (currently 7s each), will be reduced to 2s in upcoming PR.

Virtually all new blocks have events, so this is unlikely to trigger when syncing current data unless it's really an issue.