### PR TITLE
feat: add consistent network verification

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -138,6 +138,8 @@ export default class Checkpoint {
   public async start() {
     this.log.debug('starting');
 
+    await this.validateStore();
+
     const blockNum = await this.getStartBlockNum();
     return await this.next(blockNum);
   }
@@ -404,6 +406,24 @@ export default class Checkpoint {
           .map(writer => writer.fn)
           .join(', ')}), but they are not defined`
       );
+    }
+  }
+
+  private async validateStore() {
+    const networkIdentifier = await this.networkProvider.getNetworkIdentifier();
+    const storedNetworkIdentifier = await this.store.getMetadata(MetadataId.NetworkIdentifier);
+    const hasNetworkChanged = storedNetworkIdentifier !== networkIdentifier;
+
+    if (!storedNetworkIdentifier || (hasNetworkChanged && this.opts?.ignoreNetworkChange)) {
+      await this.store.setMetadata(MetadataId.NetworkIdentifier, networkIdentifier);
+    } else if (hasNetworkChanged) {
+      this.log.error(
+        `network identifier changed from ${storedNetworkIdentifier} to ${networkIdentifier}.
+        You probably should reset the database by calling .reset() and resetMetadata().
+        If you are sure you want to continue, set ignoreNetworkChange to true in Checkpoint options.`
+      );
+
+      throw new Error('network identifier changed');
     }
   }
 }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -44,6 +44,10 @@ export class BaseProvider {
     }
   }
 
+  getNetworkIdentifier(): Promise<string> {
+    throw new Error('getNetworkIdentifier method was not defined');
+  }
+
   processBlock(blockNum: number): Promise<number> {
     throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
   }

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -25,6 +25,11 @@ export class StarknetProvider extends BaseProvider {
     });
   }
 
+  async getNetworkIdentifier(): Promise<string> {
+    const result = await this.provider.getChainId();
+    return `starknet_${result}`;
+  }
+
   async processBlock(blockNum: number) {
     let block: Block;
     let blockEvents: EventsMap;

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -33,7 +33,8 @@ export interface CheckpointRecord {
  *
  */
 export enum MetadataId {
-  LastIndexedBlock = 'last_indexed_block'
+  LastIndexedBlock = 'last_indexed_block',
+  NetworkIdentifier = 'network_identifier'
 }
 
 const CheckpointIdSize = 10;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,9 @@ export type EventsMap = { [key: string]: Event[] };
 export type ParsedEvent = Record<string, any>;
 
 export interface CheckpointOptions {
+  // Setting to true will ignore network changes. You probably don't want to set it,
+  // and instead perform database reset when switching networks.
+  ignoreNetworkChange?: boolean;
   // Set the log output levels for checkpoint. Defaults to Error.
   // Note, this does not affect the log outputs in writers.
   logLevel?: LogLevel;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,8 @@ export type EventsMap = { [key: string]: Event[] };
 export type ParsedEvent = Record<string, any>;
 
 export interface CheckpointOptions {
-  // Setting to true will ignore network changes. You probably don't want to set it,
-  // and instead perform database reset when switching networks.
-  ignoreNetworkChange?: boolean;
+  // Setting to true will trigger reset of database on config changes.
+  resetOnConfigChange?: boolean;
   // Set the log output levels for checkpoint. Defaults to Error.
   // Note, this does not affect the log outputs in writers.
   logLevel?: LogLevel;


### PR DESCRIPTION
Towards https://github.com/checkpoint-labs/checkpoint/issues/198

This PR adds verification that network returned by provider is the same as previously used.

## Test plan

- Start the server normally so network gets persisted.
- Change `network_node_url` in your config to different network.
- Start the server. You get error message.
- Set `resetOnConfigChange` to true in options, start server again, it continues.
- Remove this option, start server again, it works.