### PR TITLE
feat: continue fetching receipts on error

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -280,10 +280,10 @@ export default class Checkpoint {
         try {
           await this.networkProvider.processPool(blockNum);
         } catch (err) {
-          this.log.error({ blockNumber: blockNum, err }, 'error occured during pool processing');
+          this.log.error({ blockNumber: blockNum, err }, 'error occurred during pool processing');
         }
       } else {
-        this.log.error({ blockNumber: blockNum, err }, 'error occured during block processing');
+        this.log.error({ blockNumber: blockNum, err }, 'error occurred during block processing');
       }
 
       await Promise.delay(REFRESH_INTERVAL);

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -62,7 +62,7 @@ export class StarknetProvider extends BaseProvider {
         try {
           return await this.provider.getTransactionReceipt(tx.transaction_hash);
         } catch (err) {
-          this.log.error(
+          this.log.warn(
             { transactionHash: tx.transaction_hash, err },
             'getting transaction receipt failed'
           );

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -59,7 +59,15 @@ export class StarknetProvider extends BaseProvider {
       txs.map(async tx => {
         if (!tx.transaction_hash) return null;
 
-        return this.provider.getTransactionReceipt(tx.transaction_hash);
+        try {
+          return await this.provider.getTransactionReceipt(tx.transaction_hash);
+        } catch (err) {
+          this.log.error(
+            { transactionHash: tx.transaction_hash, err },
+            'getting transaction receipt failed'
+          );
+          return null;
+        }
       })
     );
 

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -71,6 +71,7 @@ export class StarknetProvider extends BaseProvider {
       })
     );
 
+    const txsWithReceipts = txs.filter((_, index) => receipts[index] !== null);
     const eventsMap = receipts.reduce((acc, receipt) => {
       if (receipt === null) return acc;
 
@@ -78,7 +79,7 @@ export class StarknetProvider extends BaseProvider {
       return acc;
     }, {});
 
-    await this.handlePool(txs, eventsMap, blockNumber);
+    await this.handlePool(txsWithReceipts, eventsMap, blockNumber);
   }
 
   private async handleBlock(block: FullBlock, eventsMap: EventsMap) {


### PR DESCRIPTION
Currently, `processPool` is aborted if a single `getTransactionReceipt` throws. Instead, process the receipts that do get returned. It's quite common for a pending transaction receipt to be missing when hitting a cluster of nodes.