### PR TITLE
feat: detect events and generic config changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "json-to-graphql-query": "^2.2.4",
     "knex": "^2.4.2",
     "mysql": "^2.18.1",
+    "object-hash": "^3.0.0",
     "pg": "^8.10.0",
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -456,12 +456,18 @@ export default class Checkpoint {
       );
 
       throw new Error('config changed');
-    } else if (!storedNetworkIdentifier) {
-      await this.store.setMetadata(MetadataId.NetworkIdentifier, networkIdentifier);
-    } else if (!storedStartBlock) {
-      await this.store.setMetadata(MetadataId.StartBlock, this.getConfigStartBlock());
-    } else if (!storedConfigChecksum) {
-      await this.store.setMetadata(MetadataId.ConfigChecksum, configChecksum);
+    } else {
+      if (!storedNetworkIdentifier) {
+        await this.store.setMetadata(MetadataId.NetworkIdentifier, networkIdentifier);
+      }
+
+      if (!storedStartBlock) {
+        await this.store.setMetadata(MetadataId.StartBlock, this.getConfigStartBlock());
+      }
+
+      if (!storedConfigChecksum) {
+        await this.store.setMetadata(MetadataId.ConfigChecksum, configChecksum);
+      }
     }
   }
 }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -7,7 +7,7 @@ import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './g
 import { GqlEntityController } from './graphql/controller';
 import { BaseProvider, StarknetProvider, BlockNotFoundError } from './providers';
 import { createLogger, Logger, LogLevel } from './utils/logger';
-import { getContractsFromConfig } from './utils/checkpoint';
+import { getConfigChecksum, getContractsFromConfig } from './utils/checkpoint';
 import { extendSchema } from './utils/graphql';
 import { createKnex } from './knex';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
@@ -411,23 +411,31 @@ export default class Checkpoint {
 
   private async validateStore() {
     const networkIdentifier = await this.networkProvider.getNetworkIdentifier();
+    const configChecksum = getConfigChecksum(this.config);
+
     const storedNetworkIdentifier = await this.store.getMetadata(MetadataId.NetworkIdentifier);
     const storedStartBlock = await this.store.getMetadataNumber(MetadataId.StartBlock);
+    const storedConfigChecksum = await this.store.getMetadata(MetadataId.ConfigChecksum);
     const hasNetworkChanged =
       storedNetworkIdentifier && storedNetworkIdentifier !== networkIdentifier;
     const hasStartBlockChanged =
       storedStartBlock && storedStartBlock !== this.getConfigStartBlock();
+    const hasConfigChanged = storedConfigChecksum && storedConfigChecksum !== configChecksum;
 
-    if ((hasNetworkChanged || hasStartBlockChanged) && this.opts?.resetOnConfigChange) {
+    if (
+      (hasNetworkChanged || hasStartBlockChanged || hasConfigChanged) &&
+      this.opts?.resetOnConfigChange
+    ) {
       await this.resetMetadata();
       await this.reset();
 
       await this.store.setMetadata(MetadataId.NetworkIdentifier, networkIdentifier);
       await this.store.setMetadata(MetadataId.StartBlock, this.getConfigStartBlock());
+      await this.store.setMetadata(MetadataId.ConfigChecksum, configChecksum);
     } else if (hasNetworkChanged) {
       this.log.error(
         `network identifier changed from ${storedNetworkIdentifier} to ${networkIdentifier}.
-          You probably should reset the database by calling .reset() and resetMetadata().
+        You probably should reset the database by calling .reset() and resetMetadata().
           You can also set resetOnConfigChange to true in Checkpoint options to do this automatically.`
       );
 
@@ -435,15 +443,25 @@ export default class Checkpoint {
     } else if (hasStartBlockChanged) {
       this.log.error(
         `start block changed from ${storedStartBlock} to ${this.getConfigStartBlock()}.
+        You probably should reset the database by calling .reset() and resetMetadata().
+        You can also set resetOnConfigChange to true in Checkpoint options to do this automatically.`
+      );
+
+      throw new Error('start block changed');
+    } else if (hasConfigChanged) {
+      this.log.error(
+        `config checksum changed from ${storedConfigChecksum} to ${configChecksum} to due to a change in the config.
           You probably should reset the database by calling .reset() and resetMetadata().
           You can also set resetOnConfigChange to true in Checkpoint options to do this automatically.`
       );
 
-      throw new Error('start block changed');
+      throw new Error('config changed');
     } else if (!storedNetworkIdentifier) {
       await this.store.setMetadata(MetadataId.NetworkIdentifier, networkIdentifier);
     } else if (!storedStartBlock) {
       await this.store.setMetadata(MetadataId.StartBlock, this.getConfigStartBlock());
+    } else if (!storedConfigChecksum) {
+      await this.store.setMetadata(MetadataId.ConfigChecksum, configChecksum);
     }
   }
 }

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -116,7 +116,7 @@ export class CheckpointsStore {
     }
 
     if (hasMetadataTable) {
-      await this.knex(Table.Checkpoints).truncate();
+      await this.knex(Table.Metadata).truncate();
     }
 
     this.log.debug('checkpoints tables truncated');

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -35,7 +35,8 @@ export interface CheckpointRecord {
 export enum MetadataId {
   LastIndexedBlock = 'last_indexed_block',
   NetworkIdentifier = 'network_identifier',
-  StartBlock = 'start_block'
+  StartBlock = 'start_block',
+  ConfigChecksum = 'config_checksum'
 }
 
 const CheckpointIdSize = 10;

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -1,5 +1,30 @@
-import { CheckpointConfig } from '../types';
+import objectHash from 'object-hash';
+import { CheckpointConfig, ContractSourceConfig, ContractTemplate } from '../types';
 
 export const getContractsFromConfig = (config: CheckpointConfig): string[] => {
   return (config.sources || []).map(source => source.contract);
+};
+
+const getHashableProperties = (config: ContractTemplate | ContractSourceConfig) => ({
+  contract: 'contract' in config ? config.contract : undefined,
+  start: 'start' in config ? config.start : undefined,
+  events: (config.events || []).map(event => event.name)
+});
+
+export const getConfigChecksum = (config: CheckpointConfig): string => {
+  const { tx_fn, global_events, sources, templates } = config;
+
+  return objectHash(
+    {
+      tx_fn,
+      global_events,
+      sources: (sources || []).map(source => getHashableProperties(source)),
+      templates: Object.fromEntries(
+        Object.entries(templates || {}).map(([key, value]) => [key, getHashableProperties(value)])
+      )
+    },
+    {
+      unorderedArrays: true
+    }
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3498,6 +3498,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
+
 on-exit-leak-free@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-1.0.0.tgz#4a2accb382278a266848bb1a21439e5fc3cd9881"


### PR DESCRIPTION
Depends on: https://github.com/checkpoint-labs/checkpoint/pull/232
Closes: https://github.com/checkpoint-labs/checkpoint/issues/198

This PR adds verification that tracked events didn't change.

## Test plan

- Start the server normally so start checksum gets persisted.
- Do some change in the config that you expect that should be detected (writer/abi names are not considered as they are user defined).
- Start the server. You get error message.
- Set `resetOnConfigChange` to true in options, start server again, it continues.
- Remove this option, start server again, it works.