### PR TITLE
feat: add codegen to generate ORM models from schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
     "pluralize": "^8.0.0",
-    "starknet": "^4.13.1"
+    "starknet": "^4.13.1",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@snapshot-labs/checkpoint",
   "version": "0.1.0-beta.17",
   "license": "MIT",
+  "bin": {
+    "checkpoint": "dist/src/bin/index.js"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+import fs from 'fs/promises';
+import process from 'process';
+import { codegen } from '../codegen';
+
+const DEFAULT_SCHEMA_PATH = 'src/schema.gql';
+const OUTPUT_PATH = 'codegen/models.ts';
+
+async function run() {
+  if (process.argv[2] !== 'codegen') {
+    console.log('Usage:\n\tcheckpoint codegen');
+    process.exit(1);
+  }
+
+  const schemaFile = process.argv[3] ?? DEFAULT_SCHEMA_PATH;
+
+  console.log('Generating models from schema:', schemaFile);
+
+  const cwd = process.cwd();
+  const schemaFilePath = path.join(cwd, schemaFile);
+  const schema = await fs.readFile(schemaFilePath, 'utf8');
+
+  const generatedModels = codegen(schema);
+
+  await fs.mkdir(path.join(cwd, 'codegen'), { recursive: true });
+  await fs.writeFile(path.join(cwd, OUTPUT_PATH), generatedModels);
+
+  console.log('Models generated to', OUTPUT_PATH);
+}
+
+run();

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,31 +1,73 @@
 import path from 'path';
 import fs from 'fs/promises';
 import process from 'process';
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
 import { codegen } from '../codegen';
+import { CheckpointConfig } from '../types';
 
+const DEFAULT_CONFIG_PATH = 'src/config.json';
 const DEFAULT_SCHEMA_PATH = 'src/schema.gql';
-const OUTPUT_PATH = 'codegen/models.ts';
+const OUTPUT_DIRECTORY = '.checkpoint';
 
-async function run() {
-  if (process.argv[2] !== 'codegen') {
-    console.log('Usage:\n\tcheckpoint codegen');
-    process.exit(1);
+async function generate(schemaFile: string, configFile: string, format: string) {
+  if (format !== 'typescript' && format !== 'javascript') {
+    throw new Error('Invalid output format');
   }
-
-  const schemaFile = process.argv[3] ?? DEFAULT_SCHEMA_PATH;
 
   console.log('Generating models from schema:', schemaFile);
 
   const cwd = process.cwd();
   const schemaFilePath = path.join(cwd, schemaFile);
+  const configFilePath = path.join(cwd, configFile);
+
   const schema = await fs.readFile(schemaFilePath, 'utf8');
+  const config: CheckpointConfig = await import(configFilePath);
 
-  const generatedModels = codegen(schema, 'typescript');
+  const generatedModels = codegen(schema, config, format);
 
-  await fs.mkdir(path.join(cwd, 'codegen'), { recursive: true });
-  await fs.writeFile(path.join(cwd, OUTPUT_PATH), generatedModels);
+  const outputFile = format === 'typescript' ? 'models.ts' : 'models.js';
+  const outputPath = path.join(OUTPUT_DIRECTORY, outputFile);
 
-  console.log('Models generated to', OUTPUT_PATH);
+  await fs.mkdir(path.join(cwd, OUTPUT_DIRECTORY), { recursive: true });
+  await fs.writeFile(path.join(cwd, outputPath), generatedModels);
+
+  console.log('Models generated to', outputPath);
 }
 
-run();
+yargs(hideBin(process.argv))
+  .command(
+    'generate',
+    'generate models from schema',
+    yargs => {
+      return yargs
+        .option('schema-file', {
+          alias: 's',
+          type: 'string',
+          default: DEFAULT_SCHEMA_PATH,
+          description: 'Schema file path'
+        })
+        .option('config-file', {
+          alias: 'c',
+          type: 'string',
+          default: DEFAULT_CONFIG_PATH,
+          description: 'Config file path'
+        })
+        .option('output-format', {
+          alias: 'f',
+          type: 'string',
+          default: 'typescript',
+          description: 'Output format (typescript or javascript)'
+        });
+    },
+    async argv => {
+      try {
+        await generate(argv['schema-file'], argv['config-file'], argv['output-format']);
+      } catch (err) {
+        console.error('Error generating models:', err);
+        process.exit(1);
+      }
+    }
+  )
+  .demandCommand(1, 'You need to specify a command')
+  .parse();

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -20,7 +20,7 @@ async function run() {
   const schemaFilePath = path.join(cwd, schemaFile);
   const schema = await fs.readFile(schemaFilePath, 'utf8');
 
-  const generatedModels = codegen(schema);
+  const generatedModels = codegen(schema, 'typescript');
 
   await fs.mkdir(path.join(cwd, 'codegen'), { recursive: true });
   await fs.writeFile(path.join(cwd, OUTPUT_PATH), generatedModels);

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -8,6 +8,7 @@ import { GqlEntityController } from './graphql/controller';
 import { BaseProvider, StarknetProvider, BlockNotFoundError } from './providers';
 import { createLogger, Logger, LogLevel } from './utils/logger';
 import { getContractsFromConfig } from './utils/checkpoint';
+import { extendSchema } from './utils/graphql';
 import { createKnex } from './knex';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
 import { createPgPool } from './pg';
@@ -49,7 +50,7 @@ export default class Checkpoint {
     this.config = config;
     this.writer = writer;
     this.opts = opts;
-    this.schema = this.extendSchema(schema);
+    this.schema = extendSchema(schema);
 
     this.validateConfig();
 
@@ -373,11 +374,6 @@ export default class Checkpoint {
         }
       }
     ) as PgPool;
-  }
-
-  private extendSchema(schema: string): string {
-    return `directive @derivedFrom(field: String!) on FIELD_DEFINITION
-${schema}`;
   }
 
   private validateConfig() {

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -54,7 +54,7 @@ export default class Checkpoint {
 
     this.validateConfig();
 
-    this.entityController = new GqlEntityController(this.schema, opts);
+    this.entityController = new GqlEntityController(this.schema, config);
 
     this.sourceContracts = getContractsFromConfig(config);
     this.cpBlocksCache = [];

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -14,6 +14,7 @@ import {
 import pluralize from 'pluralize';
 import { GqlEntityController } from './graphql/controller';
 import { extendSchema } from './utils/graphql';
+import { CheckpointConfig } from './types';
 
 type TypeInfo = {
   type: string;
@@ -86,9 +87,13 @@ export const getJSType = (field: GraphQLField<any, any>) => {
   return { isNullable, isList, baseType };
 };
 
-export const codegen = (schema: string, format: 'typescript' | 'javascript') => {
+export const codegen = (
+  schema: string,
+  config: CheckpointConfig,
+  format: 'typescript' | 'javascript'
+) => {
   const extendedSchema = extendSchema(schema);
-  const controller = new GqlEntityController(extendedSchema);
+  const controller = new GqlEntityController(extendedSchema, config);
 
   const preamble = `import { Model } from '@snapshot-labs/checkpoint';\n\n`;
 

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -31,8 +31,8 @@ export const getInitialValue = (field: GraphQLField<any, any>) => {
       return '';
   }
 
-  if (field instanceof GraphQLScalarType) {
-    switch (field.name) {
+  if (nonNullType instanceof GraphQLScalarType) {
+    switch (nonNullType.name) {
       case 'BigInt':
         return 0;
       case 'Boolean':
@@ -46,7 +46,7 @@ export const getInitialValue = (field: GraphQLField<any, any>) => {
     }
   }
 
-  if (field instanceof GraphQLList) {
+  if (nonNullType instanceof GraphQLList) {
     return [];
   }
 
@@ -54,7 +54,9 @@ export const getInitialValue = (field: GraphQLField<any, any>) => {
 };
 
 export const getBaseType = (type: GraphQLType) => {
-  switch (type) {
+  const nonNullType = type instanceof GraphQLNonNull ? type.ofType : type;
+
+  switch (nonNullType) {
     case GraphQLInt:
     case GraphQLFloat:
       return 'number';
@@ -63,12 +65,12 @@ export const getBaseType = (type: GraphQLType) => {
       return 'string';
   }
 
-  if (type instanceof GraphQLObjectType) {
+  if (nonNullType instanceof GraphQLObjectType) {
     return 'string';
   }
 
-  if (type instanceof GraphQLScalarType) {
-    switch (type.name) {
+  if (nonNullType instanceof GraphQLScalarType) {
+    switch (nonNullType.name) {
       case 'BigInt':
         return 'bigint';
       case 'Boolean':
@@ -82,9 +84,8 @@ export const getBaseType = (type: GraphQLType) => {
     }
   }
 
-  if (type instanceof GraphQLList) {
-    const nonNullType = type.ofType instanceof GraphQLNonNull ? type.ofType.ofType : type.ofType;
-    return `${getBaseType(nonNullType)}[]`;
+  if (nonNullType instanceof GraphQLList) {
+    return `${getBaseType(nonNullType.ofType)}[]`;
   }
 
   return null;

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,0 +1,165 @@
+import {
+  GraphQLField,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLString,
+  GraphQLType,
+  isListType
+} from 'graphql';
+import pluralize from 'pluralize';
+import { GqlEntityController } from './graphql/controller';
+import { extendSchema } from './utils/graphql';
+
+export const getInitialValue = (field: GraphQLField<any, any>) => {
+  if (!(field.type instanceof GraphQLNonNull)) {
+    return null;
+  }
+
+  const nonNullType = field.type.ofType;
+
+  switch (nonNullType) {
+    case GraphQLInt:
+    case GraphQLFloat:
+      return 0;
+    case GraphQLString:
+    case GraphQLID:
+      return '';
+  }
+
+  if (field instanceof GraphQLScalarType) {
+    switch (field.name) {
+      case 'BigInt':
+        return 0;
+      case 'Boolean':
+        return false;
+      case 'Text':
+        return '';
+      default:
+        // TODO: handle decimal types - currently decimal types are defined
+        // in options so we don't have access from codegen
+        return '0';
+    }
+  }
+
+  if (field instanceof GraphQLList) {
+    return [];
+  }
+
+  return null;
+};
+
+export const getBaseType = (type: GraphQLType) => {
+  switch (type) {
+    case GraphQLInt:
+    case GraphQLFloat:
+      return 'number';
+    case GraphQLString:
+    case GraphQLID:
+      return 'string';
+  }
+
+  if (type instanceof GraphQLObjectType) {
+    return 'string';
+  }
+
+  if (type instanceof GraphQLScalarType) {
+    switch (type.name) {
+      case 'BigInt':
+        return 'bigint';
+      case 'Boolean':
+        return 'boolean';
+      case 'Text':
+        return 'string';
+      default:
+        // TODO: handle decimal types - currently decimal types are defined
+        // in options so we don't have access from codegen, we just assume string
+        return 'string';
+    }
+  }
+
+  if (type instanceof GraphQLList) {
+    const nonNullType = type.ofType instanceof GraphQLNonNull ? type.ofType.ofType : type.ofType;
+    return `${getBaseType(nonNullType)}[]`;
+  }
+
+  return null;
+};
+
+export const getJSType = (field: GraphQLField<any, any>) => {
+  const nonNullType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
+  const isNullable = !(field.type instanceof GraphQLNonNull);
+  const isList = nonNullType instanceof GraphQLList;
+  const baseType = getBaseType(nonNullType);
+
+  return { isNullable, isList, baseType };
+};
+
+export const codegen = (schema: string) => {
+  const extendedSchema = extendSchema(schema);
+  const controller = new GqlEntityController(extendedSchema);
+
+  const preamble = `import { Model } from '@snapshot-labs/checkpoint';\n\n`;
+
+  let contents = `${preamble}`;
+
+  controller.schemaObjects.forEach((type, i, arr) => {
+    const modelName = type.name;
+
+    contents += `export class ${modelName} extends Model {\n`;
+    contents += `  static tableName = '${pluralize(modelName.toLowerCase())}';\n\n`;
+
+    contents += `  constructor(id: string) {\n`;
+    contents += `    super(${modelName}.tableName);\n\n`;
+    controller.getTypeFields(type).forEach(field => {
+      const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
+      if (isListType(fieldType) && fieldType.ofType instanceof GraphQLObjectType) {
+        return;
+      }
+
+      const initialValue = field.name === 'id' ? 'id' : JSON.stringify(getInitialValue(field));
+      contents += `    this.initialSet('${field.name}', ${initialValue});\n`;
+    });
+    contents += `  }\n\n`;
+
+    contents += `  static async loadEntity(id: string): Promise<${modelName} | null> {\n`;
+    contents += `    const entity = await super.loadEntity(${modelName}.tableName, id);\n`;
+    contents += `    if (!entity) return null;\n\n`;
+    contents += `    const model = new ${modelName}(id);\n`;
+    contents += `    model.setExists();\n\n`;
+    contents += `    for (const key in entity) {\n`;
+    contents += `      model.set(key, entity[key]);\n`;
+    contents += `    }\n\n`;
+    contents += `    return model;\n`;
+    contents += `  }\n\n`;
+
+    controller.getTypeFields(type).forEach(field => {
+      const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
+      if (isListType(fieldType) && fieldType.ofType instanceof GraphQLObjectType) {
+        return;
+      }
+
+      const { isNullable, isList, baseType } = getJSType(field);
+      const typeAnnotation = isNullable ? `${baseType} | null` : baseType;
+
+      contents += `  get ${field.name}(): ${typeAnnotation} {\n`;
+      contents += `    return ${
+        isList ? `JSON.parse(this.get('${field.name}'))` : `this.get('${field.name}')`
+      };\n`;
+      contents += `  }\n\n`;
+
+      contents += `  set ${field.name}(value: ${typeAnnotation}) {\n`;
+      contents += `    this.set('${field.name}', ${isList ? `JSON.stringify(value)` : 'value'});\n`;
+      contents += `  }\n\n`;
+    });
+
+    contents = contents.slice(0, -1);
+    contents += i === arr.length - 1 ? '}\n' : '}\n\n';
+  });
+
+  return contents;
+};

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -202,7 +202,7 @@ export class GqlEntityController {
     }
 
     this.schemaObjects.map(type => {
-      const tableName = pluralize(pluralize(type.name.toLowerCase()));
+      const tableName = pluralize(type.name.toLowerCase());
 
       builder = builder.dropTableIfExists(tableName).createTable(tableName, t => {
         t.primary(['id']);
@@ -260,7 +260,7 @@ export class GqlEntityController {
    * Note: that the returned objects does not include the Query object type if defined.
    *
    */
-  private get schemaObjects(): GraphQLObjectType[] {
+  public get schemaObjects(): GraphQLObjectType[] {
     if (this._schemaObjects) {
       return this._schemaObjects;
     }
@@ -274,7 +274,7 @@ export class GqlEntityController {
     return this._schemaObjects;
   }
 
-  private getTypeFields<Parent, Context>(
+  public getTypeFields<Parent, Context>(
     type: GraphQLObjectType<Parent, Context>
   ): GraphQLField<Parent, Context>[] {
     return Object.values(type.getFields());

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -30,7 +30,7 @@ import {
   singleEntityQueryName,
   getNonNullType
 } from '../utils/graphql';
-import { CheckpointOptions } from '../types';
+import { CheckpointConfig, CheckpointOptions } from '../types';
 import { querySingle, queryMulti, ResolverContext, getNestedResolver } from './resolvers';
 
 /**
@@ -59,12 +59,12 @@ const GraphQLOrderDirection = new GraphQLEnumType({
  */
 export class GqlEntityController {
   private readonly schema: GraphQLSchema;
-  private readonly decimalTypes: NonNullable<CheckpointOptions['decimalTypes']>;
+  private readonly decimalTypes: NonNullable<CheckpointConfig['decimal_types']>;
   private _schemaObjects?: GraphQLObjectType[];
 
-  constructor(typeDefs: string | Source, opts?: CheckpointOptions) {
+  constructor(typeDefs: string | Source, config?: CheckpointConfig) {
     this.schema = buildSchema(typeDefs);
-    this.decimalTypes = opts?.decimalTypes || {
+    this.decimalTypes = config?.decimal_types || {
       Decimal: {
         p: 10,
         d: 2

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,6 @@ export interface CheckpointOptions {
   // connection string. If no provided will default to looking up a value in
   // the DATABASE_URL environment.
   dbConnection?: string;
-  // Configuration for decimal types
-  // defaults to Decimal(10, 2), BigDecimal(20, 8)
-  decimalTypes?: { [key: string]: { p: number; d: number } };
   // Abis for contracts needed for automatic event parsing
   abis?: Record<string, any>;
   // BaseProvider based class that defines how blocks are fetched and processed.
@@ -67,6 +64,9 @@ export type ContractTemplate = {
 export interface CheckpointConfig {
   network_node_url: string;
   optimistic_indexing?: boolean;
+  // Configuration for decimal types
+  // defaults to Decimal(10, 2), BigDecimal(20, 8)
+  decimal_types?: { [key: string]: { p: number; d: number } };
   start?: number;
   tx_fn?: string;
   global_events?: ContractEventConfig[];

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -9,6 +9,11 @@ import {
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import pluralize from 'pluralize';
 
+export const extendSchema = (schema: string): string => {
+  return `directive @derivedFrom(field: String!) on FIELD_DEFINITION
+${schema}`;
+};
+
 /**
  * Returns name of query for fetching single entity record
  *

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -1,6 +1,192 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`codegen should generate code 1`] = `
+exports[`codegen should generate javascript code 1`] = `
+"import { Model } from '@snapshot-labs/checkpoint';
+
+export class Space extends Model {
+  static tableName = 'spaces';
+
+  constructor(id) {
+    super(Space.tableName);
+
+    this.initialSet('id', id);
+    this.initialSet('name', null);
+    this.initialSet('about', null);
+    this.initialSet('controller', "");
+    this.initialSet('voting_delay', 0);
+    this.initialSet('proposal_threshold', 0);
+    this.initialSet('quorum', 0);
+    this.initialSet('strategies', []);
+  }
+
+  static async loadEntity(id) {
+    const entity = await super.loadEntity(Space.tableName, id);
+    if (!entity) return null;
+
+    const model = new Space(id);
+    model.setExists();
+
+    for (const key in entity) {
+      model.set(key, entity[key]);
+    }
+
+    return model;
+  }
+
+  get id() {
+    return this.get('id');
+  }
+
+  set id(value) {
+    this.set('id', value);
+  }
+
+  get name() {
+    return this.get('name');
+  }
+
+  set name(value) {
+    this.set('name', value);
+  }
+
+  get about() {
+    return this.get('about');
+  }
+
+  set about(value) {
+    this.set('about', value);
+  }
+
+  get controller() {
+    return this.get('controller');
+  }
+
+  set controller(value) {
+    this.set('controller', value);
+  }
+
+  get voting_delay() {
+    return this.get('voting_delay');
+  }
+
+  set voting_delay(value) {
+    this.set('voting_delay', value);
+  }
+
+  get proposal_threshold() {
+    return this.get('proposal_threshold');
+  }
+
+  set proposal_threshold(value) {
+    this.set('proposal_threshold', value);
+  }
+
+  get quorum() {
+    return this.get('quorum');
+  }
+
+  set quorum(value) {
+    this.set('quorum', value);
+  }
+
+  get strategies() {
+    return JSON.parse(this.get('strategies'));
+  }
+
+  set strategies(value) {
+    this.set('strategies', JSON.stringify(value));
+  }
+}
+
+export class Proposal extends Model {
+  static tableName = 'proposals';
+
+  constructor(id) {
+    super(Proposal.tableName);
+
+    this.initialSet('id', id);
+    this.initialSet('proposal_id', 0);
+    this.initialSet('space', "");
+    this.initialSet('title', "");
+    this.initialSet('scores_total', 0);
+    this.initialSet('active', false);
+    this.initialSet('progress', "0");
+  }
+
+  static async loadEntity(id) {
+    const entity = await super.loadEntity(Proposal.tableName, id);
+    if (!entity) return null;
+
+    const model = new Proposal(id);
+    model.setExists();
+
+    for (const key in entity) {
+      model.set(key, entity[key]);
+    }
+
+    return model;
+  }
+
+  get id() {
+    return this.get('id');
+  }
+
+  set id(value) {
+    this.set('id', value);
+  }
+
+  get proposal_id() {
+    return this.get('proposal_id');
+  }
+
+  set proposal_id(value) {
+    this.set('proposal_id', value);
+  }
+
+  get space() {
+    return this.get('space');
+  }
+
+  set space(value) {
+    this.set('space', value);
+  }
+
+  get title() {
+    return this.get('title');
+  }
+
+  set title(value) {
+    this.set('title', value);
+  }
+
+  get scores_total() {
+    return this.get('scores_total');
+  }
+
+  set scores_total(value) {
+    this.set('scores_total', value);
+  }
+
+  get active() {
+    return this.get('active');
+  }
+
+  set active(value) {
+    this.set('active', value);
+  }
+
+  get progress() {
+    return this.get('progress');
+  }
+
+  set progress(value) {
+    this.set('progress', value);
+  }
+}
+"
+`;
+
+exports[`codegen should generate typescript code 1`] = `
 "import { Model } from '@snapshot-labs/checkpoint';
 
 export class Space extends Model {

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`codegen should generate code 1`] = `
+"import { Model } from '@snapshot-labs/checkpoint';
+
+export class Space extends Model {
+  static tableName = 'spaces';
+
+  constructor(id: string) {
+    super(Space.tableName);
+
+    this.initialSet('id', id);
+    this.initialSet('name', null);
+    this.initialSet('about', null);
+    this.initialSet('controller', "");
+    this.initialSet('voting_delay', 0);
+    this.initialSet('proposal_threshold', 0);
+    this.initialSet('quorum', 0);
+    this.initialSet('strategies', []);
+  }
+
+  static async loadEntity(id: string): Promise<Space | null> {
+    const entity = await super.loadEntity(Space.tableName, id);
+    if (!entity) return null;
+
+    const model = new Space(id);
+    model.setExists();
+
+    for (const key in entity) {
+      model.set(key, entity[key]);
+    }
+
+    return model;
+  }
+
+  get id(): string {
+    return this.get('id');
+  }
+
+  set id(value: string) {
+    this.set('id', value);
+  }
+
+  get name(): string | null {
+    return this.get('name');
+  }
+
+  set name(value: string | null) {
+    this.set('name', value);
+  }
+
+  get about(): string | null {
+    return this.get('about');
+  }
+
+  set about(value: string | null) {
+    this.set('about', value);
+  }
+
+  get controller(): string {
+    return this.get('controller');
+  }
+
+  set controller(value: string) {
+    this.set('controller', value);
+  }
+
+  get voting_delay(): number {
+    return this.get('voting_delay');
+  }
+
+  set voting_delay(value: number) {
+    this.set('voting_delay', value);
+  }
+
+  get proposal_threshold(): bigint {
+    return this.get('proposal_threshold');
+  }
+
+  set proposal_threshold(value: bigint) {
+    this.set('proposal_threshold', value);
+  }
+
+  get quorum(): number {
+    return this.get('quorum');
+  }
+
+  set quorum(value: number) {
+    this.set('quorum', value);
+  }
+
+  get strategies(): string[] {
+    return JSON.parse(this.get('strategies'));
+  }
+
+  set strategies(value: string[]) {
+    this.set('strategies', JSON.stringify(value));
+  }
+}
+
+export class Proposal extends Model {
+  static tableName = 'proposals';
+
+  constructor(id: string) {
+    super(Proposal.tableName);
+
+    this.initialSet('id', id);
+    this.initialSet('proposal_id', 0);
+    this.initialSet('space', null);
+    this.initialSet('title', "");
+    this.initialSet('scores_total', 0);
+    this.initialSet('active', false);
+    this.initialSet('progress', "0");
+  }
+
+  static async loadEntity(id: string): Promise<Proposal | null> {
+    const entity = await super.loadEntity(Proposal.tableName, id);
+    if (!entity) return null;
+
+    const model = new Proposal(id);
+    model.setExists();
+
+    for (const key in entity) {
+      model.set(key, entity[key]);
+    }
+
+    return model;
+  }
+
+  get id(): string {
+    return this.get('id');
+  }
+
+  set id(value: string) {
+    this.set('id', value);
+  }
+
+  get proposal_id(): number {
+    return this.get('proposal_id');
+  }
+
+  set proposal_id(value: number) {
+    this.set('proposal_id', value);
+  }
+
+  get space(): string {
+    return this.get('space');
+  }
+
+  set space(value: string) {
+    this.set('space', value);
+  }
+
+  get title(): string {
+    return this.get('title');
+  }
+
+  set title(value: string) {
+    this.set('title', value);
+  }
+
+  get scores_total(): bigint {
+    return this.get('scores_total');
+  }
+
+  set scores_total(value: bigint) {
+    this.set('scores_total', value);
+  }
+
+  get active(): boolean {
+    return this.get('active');
+  }
+
+  set active(value: boolean) {
+    this.set('active', value);
+  }
+
+  get progress(): string {
+    return this.get('progress');
+  }
+
+  set progress(value: string) {
+    this.set('progress', value);
+  }
+}
+"
+`;

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -106,7 +106,7 @@ export class Proposal extends Model {
 
     this.initialSet('id', id);
     this.initialSet('proposal_id', 0);
-    this.initialSet('space', null);
+    this.initialSet('space', "");
     this.initialSet('title', "");
     this.initialSet('scores_total', 0);
     this.initialSet('active', false);

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -17,6 +17,7 @@ export class Space extends Model {
     this.initialSet('proposal_threshold', 0);
     this.initialSet('quorum', 0);
     this.initialSet('strategies', []);
+    this.initialSet('strategies_nonnull', []);
   }
 
   static async loadEntity(id) {
@@ -95,6 +96,14 @@ export class Space extends Model {
 
   set strategies(value) {
     this.set('strategies', JSON.stringify(value));
+  }
+
+  get strategies_nonnull() {
+    return JSON.parse(this.get('strategies_nonnull'));
+  }
+
+  set strategies_nonnull(value) {
+    this.set('strategies_nonnull', JSON.stringify(value));
   }
 }
 
@@ -203,6 +212,7 @@ export class Space extends Model {
     this.initialSet('proposal_threshold', 0);
     this.initialSet('quorum', 0);
     this.initialSet('strategies', []);
+    this.initialSet('strategies_nonnull', []);
   }
 
   static async loadEntity(id: string): Promise<Space | null> {
@@ -281,6 +291,14 @@ export class Space extends Model {
 
   set strategies(value: string[]) {
     this.set('strategies', JSON.stringify(value));
+  }
+
+  get strategies_nonnull(): string[] {
+    return JSON.parse(this.get('strategies_nonnull'));
+  }
+
+  set strategies_nonnull(value: string[]) {
+    this.set('strategies_nonnull', JSON.stringify(value));
   }
 }
 

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -130,7 +130,11 @@ describe('getJSType', () => {
 });
 
 describe('codegen', () => {
-  it('should generate code', () => {
-    expect(codegen(SCHEMA_SOURCE)).toMatchSnapshot();
+  it('should generate typescript code', () => {
+    expect(codegen(SCHEMA_SOURCE, 'typescript')).toMatchSnapshot();
+  });
+
+  it('should generate javascript code', () => {
+    expect(codegen(SCHEMA_SOURCE, 'javascript')).toMatchSnapshot();
   });
 });

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -1,0 +1,133 @@
+import { GraphQLObjectType, buildSchema } from 'graphql';
+import { getInitialValue, getBaseType, getJSType, codegen } from '../../src/codegen';
+import { extendSchema } from '../../src/utils/graphql';
+
+const SCHEMA_SOURCE = `
+scalar Id
+scalar Text
+scalar BigInt
+scalar BigDecimal
+
+type Space {
+  id: String!
+  name: String
+  about: String
+  controller: String!
+  voting_delay: Int!
+  proposal_threshold: BigInt!
+  quorum: Float!
+  strategies: [String]!
+  proposals: [Proposal]! @derivedFrom(field: "space")
+}
+
+type Proposal {
+  id: String!
+  proposal_id: Int!
+  space: Space!
+  title: Text!
+  scores_total: BigInt!
+  active: Boolean!
+  progress: BigDecimal!
+}
+`;
+
+const schema = buildSchema(extendSchema(SCHEMA_SOURCE));
+const space = schema.getType('Space') as GraphQLObjectType;
+const proposal = schema.getType('Proposal') as GraphQLObjectType;
+const spaceFields = space.getFields();
+const proposalFields = proposal.getFields();
+
+describe('getInitialValue', () => {
+  it('should return null for nullable types', () => {
+    expect(getInitialValue(spaceFields['name'])).toBeNull();
+    expect(getInitialValue(spaceFields['about'])).toBeNull();
+  });
+
+  it('should return 0 for Int/Float/BigInt types', () => {
+    expect(getInitialValue(spaceFields['voting_delay'])).toBe(0);
+    expect(getInitialValue(spaceFields['proposal_threshold'])).toBe(0);
+    expect(getInitialValue(spaceFields['quorum'])).toBe(0);
+  });
+
+  it('should return 0 string for BigDecimal types', () => {
+    expect(getInitialValue(proposalFields['progress'])).toBe('0');
+  });
+
+  it('should return empty string for String/Text/Id types', () => {
+    expect(getInitialValue(spaceFields['id'])).toBe('');
+    expect(getInitialValue(spaceFields['controller'])).toBe('');
+    expect(getInitialValue(proposalFields['title'])).toBe('');
+  });
+
+  it('should return false for Boolean types', () => {
+    expect(getInitialValue(proposalFields['active'])).toBe(false);
+  });
+
+  it('should return empty array for List types', () => {
+    expect(getInitialValue(spaceFields['strategies'])).toEqual([]);
+  });
+
+  it('should return null for unknown types', () => {
+    // TODO: replace with real unknown time once BigDecimals are handled
+    expect(getInitialValue(proposalFields['space'])).toBeNull();
+  });
+});
+
+describe('getBaseType', () => {
+  it('should return number for Int/Float types', () => {
+    expect(getBaseType(spaceFields['voting_delay'].type)).toBe('number');
+    expect(getBaseType(proposalFields['proposal_id'].type)).toBe('number');
+  });
+
+  it('should return string for String/Text/Id types', () => {
+    expect(getBaseType(spaceFields['id'].type)).toBe('string');
+    expect(getBaseType(spaceFields['name'].type)).toBe('string');
+    expect(getBaseType(proposalFields['title'].type)).toBe('string');
+  });
+
+  it('should return string for Object types', () => {
+    expect(getBaseType(proposalFields['space'].type)).toBe('string');
+  });
+
+  it('should return bigint for BigInt types', () => {
+    expect(getBaseType(spaceFields['proposal_threshold'].type)).toBe('bigint');
+  });
+
+  it('should return boolean for Boolean types', () => {
+    expect(getBaseType(proposalFields['active'].type)).toBe('boolean');
+  });
+
+  it('should return string for BigDecimal types', () => {
+    expect(getBaseType(proposalFields['progress'].type)).toBe('string');
+  });
+
+  it('should return array type for List types', () => {
+    expect(getBaseType(spaceFields['strategies'].type)).toBe('string[]');
+  });
+
+  // TODO: handle unknown types
+});
+
+describe('getJSType', () => {
+  it('should detect nullable types', () => {
+    expect(getJSType(spaceFields['name'])).toEqual({
+      isNullable: true,
+      isList: false,
+      baseType: 'string'
+    });
+  });
+
+  it('should detect list types', () => {
+    expect(getJSType(spaceFields['strategies'])).toEqual({
+      isNullable: false,
+      isList: true,
+      baseType: 'string[]'
+    });
+  });
+});
+
+describe('codegen', () => {
+  it('should generate code', () => {
+    expect(codegen(SCHEMA_SOURCE)).toMatchSnapshot();
+  });
+});

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -130,11 +130,16 @@ describe('getJSType', () => {
 });
 
 describe('codegen', () => {
+  const config = {
+    network_node_url: '',
+    sources: []
+  };
+
   it('should generate typescript code', () => {
-    expect(codegen(SCHEMA_SOURCE, 'typescript')).toMatchSnapshot();
+    expect(codegen(SCHEMA_SOURCE, config, 'typescript')).toMatchSnapshot();
   });
 
   it('should generate javascript code', () => {
-    expect(codegen(SCHEMA_SOURCE, 'javascript')).toMatchSnapshot();
+    expect(codegen(SCHEMA_SOURCE, config, 'javascript')).toMatchSnapshot();
   });
 });

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, buildSchema } from 'graphql';
-import { getInitialValue, getBaseType, getJSType, codegen } from '../../src/codegen';
+import { getInitialValue, getBaseType, getJSType, codegen, getTypeInfo } from '../../src/codegen';
 import { extendSchema } from '../../src/utils/graphql';
 
 const SCHEMA_SOURCE = `
@@ -37,39 +37,44 @@ const proposal = schema.getType('Proposal') as GraphQLObjectType;
 const spaceFields = space.getFields();
 const proposalFields = proposal.getFields();
 
+describe('getTypeInfo', () => {
+  it('should throw when passed a wrapped type', () => {
+    expect(() => getTypeInfo(spaceFields['controller'].type)).toThrow();
+  });
+});
+
 describe('getInitialValue', () => {
   it('should return null for nullable types', () => {
-    expect(getInitialValue(spaceFields['name'])).toBeNull();
-    expect(getInitialValue(spaceFields['about'])).toBeNull();
+    expect(getInitialValue(spaceFields['name'].type)).toBeNull();
+    expect(getInitialValue(spaceFields['about'].type)).toBeNull();
   });
 
   it('should return 0 for Int/Float/BigInt types', () => {
-    expect(getInitialValue(spaceFields['voting_delay'])).toBe(0);
-    expect(getInitialValue(spaceFields['proposal_threshold'])).toBe(0);
-    expect(getInitialValue(spaceFields['quorum'])).toBe(0);
+    expect(getInitialValue(spaceFields['voting_delay'].type)).toBe(0);
+    expect(getInitialValue(spaceFields['proposal_threshold'].type)).toBe(0);
+    expect(getInitialValue(spaceFields['quorum'].type)).toBe(0);
   });
 
   it('should return 0 string for BigDecimal types', () => {
-    expect(getInitialValue(proposalFields['progress'])).toBe('0');
+    expect(getInitialValue(proposalFields['progress'].type)).toBe('0');
   });
 
   it('should return empty string for String/Text/Id types', () => {
-    expect(getInitialValue(spaceFields['id'])).toBe('');
-    expect(getInitialValue(spaceFields['controller'])).toBe('');
-    expect(getInitialValue(proposalFields['title'])).toBe('');
+    expect(getInitialValue(spaceFields['id'].type)).toBe('');
+    expect(getInitialValue(spaceFields['controller'].type)).toBe('');
+    expect(getInitialValue(proposalFields['title'].type)).toBe('');
   });
 
   it('should return false for Boolean types', () => {
-    expect(getInitialValue(proposalFields['active'])).toBe(false);
+    expect(getInitialValue(proposalFields['active'].type)).toBe(false);
   });
 
   it('should return empty array for List types', () => {
-    expect(getInitialValue(spaceFields['strategies'])).toEqual([]);
+    expect(getInitialValue(spaceFields['strategies'].type)).toEqual([]);
   });
 
-  it('should return null for unknown types', () => {
-    // TODO: replace with real unknown time once BigDecimals are handled
-    expect(getInitialValue(proposalFields['space'])).toBeNull();
+  it('should return empty string for object types', () => {
+    expect(getInitialValue(proposalFields['space'].type)).toBe('');
   });
 });
 
@@ -104,8 +109,6 @@ describe('getBaseType', () => {
   it('should return array type for List types', () => {
     expect(getBaseType(spaceFields['strategies'].type)).toBe('string[]');
   });
-
-  // TODO: handle unknown types
 });
 
 describe('getJSType', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4577,7 +4577,7 @@ yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/205
Depends on: https://github.com/checkpoint-labs/checkpoint/pull/230

This PR adds very primitive codegen for our ORM. This is exposed with `checkpoint codegen` script.

**BREAKING CHANGE: I had to move `decimalTypes` from runtime opts to CheckpointConfig as it needs to be defined statically so we can use it in scripts.**

## Test plan
- Build checkpoint.
- Go to some repo (for example [sx-api](https://github.com/snapshot-labs/sx-api/compare/sekhmet/codegen?expand=1) - this branch is converted to use ORM) that uses checkpoint and link checkpoint.
- Run `node path/to/checkpoint/dist/src/bin/index.js generate`.
- `.checkpoint/models.ts` should be generated.
- Try using models to interact with DB - if using sx-api from above repo is already converted to use this ORM.