### PR TITLE
feat: receive next block number from processBlock

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -272,9 +272,9 @@ export default class Checkpoint {
     this.log.debug({ blockNumber: blockNum }, 'next block');
 
     try {
-      await this.networkProvider.processBlock(blockNum);
+      const nextBlock = await this.networkProvider.processBlock(blockNum);
 
-      return this.next(blockNum + 1);
+      return this.next(nextBlock);
     } catch (err) {
       if (this.config.optimistic_indexing && err instanceof BlockNotFoundError) {
         try {

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -44,7 +44,7 @@ export class BaseProvider {
     }
   }
 
-  processBlock(blockNum: number) {
+  processBlock(blockNum: number): Promise<number> {
     throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
   }
 

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -51,6 +51,8 @@ export class StarknetProvider extends BaseProvider {
     await this.handleBlock(block, blockEvents);
 
     await this.instance.setLastIndexedBlock(block.block_number);
+
+    return blockNum + 1;
   }
 
   async processPool(blockNumber: number) {


### PR DESCRIPTION
This add the logic to define next block to sync in the provider directly within the `processBlock` function. This helps in some use case I'm testing where I sync a database which doesn't have blocks, in my setup a block is a transaction. But to sync the db it's not efficient to do it transaction per transaction I want to use batch of transaction instead. The issue is that if I use batch when I get close to have the db fully sync, I can not predict what will be the number of transaction available in the batch, by adding the next block within the provider `processBlock` function I can just return the last transaction order id to make sure the sync continue at the right transaction. There might be better approach to it but I found this to work well.