### PR TITLE
fix: truncate Metadata table

### DIFF
--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -116,7 +116,7 @@ export class CheckpointsStore {
     }
 
     if (hasMetadataTable) {
-      await this.knex(Table.Checkpoints).truncate();
+      await this.knex(Table.Metadata).truncate();
     }
 
     this.log.debug('checkpoints tables truncated');


### PR DESCRIPTION
Due to error we were truncating checkpoints table twice instead of checkpoints table and metadata table.