### PR TITLE
feat: add prefetch for blocks

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -323,7 +323,7 @@ export default class Checkpoint {
   }
 
   private async nextEvents(blockNum: number) {
-    if (!this.prefetchEndBlock) throw new Error('preloadEndBlock is not set');
+    if (!this.prefetchEndBlock) throw new Error('prefetchEndBlock is not set');
     if (blockNum > this.prefetchEndBlock) {
       this.prefetchDone = true;
       return;
@@ -344,7 +344,7 @@ export default class Checkpoint {
   }
 
   private async next(blockNum: number) {
-    if (!this.prefetchEndBlock) throw new Error('preloadEndBlock is not set');
+    if (!this.prefetchEndBlock) throw new Error('prefetchEndBlock is not set');
 
     if (!this.config.tx_fn && !this.config.global_events) {
       if (blockNum <= this.prefetchEndBlock) {

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -25,7 +25,7 @@ import {
 
 const BLOCK_PRELOAD = 100;
 const BLOCK_PRELOAD_OFFSET = 50;
-const DEFAULT_FETCH_INTERVAL = 7000;
+const DEFAULT_FETCH_INTERVAL = 2000;
 
 export default class Checkpoint {
   public config: CheckpointConfig;

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -178,7 +178,7 @@ export default class Checkpoint {
     this.prefetchEndBlock =
       (await this.networkProvider.getLatestBlockNumber()) - BLOCK_PRELOAD_OFFSET;
 
-    this.nextEvents(lastPrefetchedBlock);
+    this.nextEvents(Math.max(lastPrefetchedBlock, blockNum));
     return await this.next(blockNum);
   }
 

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -157,6 +157,7 @@ export default class Checkpoint {
     this.log.debug('starting');
 
     await this.validateStore();
+    await this.networkProvider.init();
 
     const templateSources = await this.store.getTemplateSources();
     await Promise.all(

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -178,7 +178,10 @@ export default class Checkpoint {
     this.prefetchEndBlock =
       (await this.networkProvider.getLatestBlockNumber()) - BLOCK_PRELOAD_OFFSET;
 
-    this.nextEvents(Math.max(lastPrefetchedBlock, blockNum));
+    if (!this.config.disable_checkpoints) {
+      this.nextEvents(Math.max(lastPrefetchedBlock, blockNum));
+    }
+
     return await this.next(blockNum);
   }
 
@@ -348,7 +351,7 @@ export default class Checkpoint {
   private async next(blockNum: number) {
     if (!this.prefetchEndBlock) throw new Error('prefetchEndBlock is not set');
 
-    if (!this.config.tx_fn && !this.config.global_events) {
+    if (!this.config.disable_checkpoints && !this.config.tx_fn && !this.config.global_events) {
       if (blockNum <= this.prefetchEndBlock) {
         const checkpointBlock = await this.getNextCheckpointBlock(blockNum);
 

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -68,9 +68,6 @@ export default class Checkpoint {
 
     this.entityController = new GqlEntityController(this.schema, config);
 
-    this.sourceContracts = getContractsFromConfig(config);
-    this.cpBlocksCache = [];
-
     this.log = createLogger({
       base: { component: 'checkpoint' },
       level: opts?.logLevel || LogLevel.Error,
@@ -85,6 +82,9 @@ export default class Checkpoint {
 
     const NetworkProvider = opts?.NetworkProvider || StarknetProvider;
     this.networkProvider = new NetworkProvider({ instance: this, log: this.log, abis: opts?.abis });
+
+    this.sourceContracts = this.networkProvider.formatAddresses(getContractsFromConfig(config));
+    this.cpBlocksCache = [];
 
     const dbConnection = opts?.dbConnection || process.env.DATABASE_URL;
     if (!dbConnection) {
@@ -221,7 +221,9 @@ export default class Checkpoint {
     if (!this.config.sources) this.config.sources = [];
 
     this.config.sources.push(source);
-    this.sourceContracts = getContractsFromConfig(this.config);
+    this.sourceContracts = this.networkProvider.formatAddresses(
+      getContractsFromConfig(this.config)
+    );
     this.cpBlocksCache = [];
   }
 

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -46,6 +46,12 @@ export class BaseProvider {
     }
   }
 
+  formatAddresses(addresses: string[]): string[] {
+    throw new Error(
+      `formatAddresses method was not defined when formatting ${addresses.length} addresses`
+    );
+  }
+
   getNetworkIdentifier(): Promise<string> {
     throw new Error('getNetworkIdentifier method was not defined');
   }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,6 +1,7 @@
 import { Pool as PgPool } from 'pg';
-import { Logger } from '../utils/logger';
 import Checkpoint from '../checkpoint';
+import { CheckpointRecord } from '../stores/checkpoints';
+import { Logger } from '../utils/logger';
 import { AsyncMySqlPool } from '../mysql';
 import { CheckpointConfig, CheckpointWriters, ContractSourceConfig } from '../types';
 
@@ -49,6 +50,10 @@ export class BaseProvider {
     throw new Error('getNetworkIdentifier method was not defined');
   }
 
+  getLatestBlockNumber(): Promise<number> {
+    throw new Error('getLatestBlockNumber method was not defined');
+  }
+
   processBlock(blockNum: number): Promise<number> {
     throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
   }
@@ -56,6 +61,12 @@ export class BaseProvider {
   processPool(blockNumber: number) {
     throw new Error(
       `processPool method was not defined when fetching pool for block ${blockNumber}`
+    );
+  }
+
+  async getCheckpointsRange(fromBlock: number, toBlock: number): Promise<CheckpointRecord[]> {
+    throw new Error(
+      `getEventsRange method was not defined when fetching events from ${fromBlock} to ${toBlock}`
     );
   }
 }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -46,6 +46,10 @@ export class BaseProvider {
     }
   }
 
+  init(): Promise<void> {
+    throw new Error('init method was not defined');
+  }
+
   formatAddresses(addresses: string[]): string[] {
     throw new Error(
       `formatAddresses method was not defined when formatting ${addresses.length} addresses`

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -26,6 +26,10 @@ export class StarknetProvider extends BaseProvider {
     });
   }
 
+  formatAddresses(addresses: string[]): string[] {
+    return addresses.map(address => validateAndParseAddress(address));
+  }
+
   async getNetworkIdentifier(): Promise<string> {
     const result = await this.provider.getChainId();
     return `starknet_${result}`;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,6 +21,7 @@ export const contractTemplateSchema = z.object({
 export const checkpointConfigSchema = z.object({
   network_node_url: z.string().url(),
   optimistic_indexing: z.boolean().optional(),
+  disable_checkpoints: z.boolean().optional(),
   decimal_types: z
     .record(
       z.object({

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { Logger } from '../utils/logger';
+import { chunk } from '../utils/helpers';
 import { TemplateSource } from '../types';
 
 const Table = {
@@ -184,34 +185,38 @@ export class CheckpointsStore {
   }
 
   public async insertCheckpoints(checkpoints: CheckpointRecord[]): Promise<void> {
-    try {
-      if (checkpoints.length === 0) {
-        return;
+    const insert = async (items: CheckpointRecord[]) => {
+      try {
+        if (items.length === 0) {
+          return;
+        }
+
+        await this.knex
+          .table(Table.Checkpoints)
+          .insert(
+            items.map(checkpoint => {
+              const id = getCheckpointId(checkpoint.contractAddress, checkpoint.blockNumber);
+
+              return {
+                [Fields.Checkpoints.Id]: id,
+                [Fields.Checkpoints.BlockNumber]: checkpoint.blockNumber,
+                [Fields.Checkpoints.ContractAddress]: checkpoint.contractAddress
+              };
+            })
+          )
+          .onConflict(Fields.Checkpoints.Id)
+          .ignore();
+      } catch (err: any) {
+        if (['ER_LOCK_DEADLOCK', '40P01'].includes(err.code)) {
+          this.log.debug('deadlock detected, retrying...');
+          return this.insertCheckpoints(items);
+        }
+
+        throw err;
       }
+    };
 
-      await this.knex
-        .table(Table.Checkpoints)
-        .insert(
-          checkpoints.map(checkpoint => {
-            const id = getCheckpointId(checkpoint.contractAddress, checkpoint.blockNumber);
-
-            return {
-              [Fields.Checkpoints.Id]: id,
-              [Fields.Checkpoints.BlockNumber]: checkpoint.blockNumber,
-              [Fields.Checkpoints.ContractAddress]: checkpoint.contractAddress
-            };
-          })
-        )
-        .onConflict(Fields.Checkpoints.Id)
-        .ignore();
-    } catch (err: any) {
-      if (err.code === 'ER_LOCK_DEADLOCK') {
-        this.log.debug('deadlock detected, retrying...');
-        return this.insertCheckpoints(checkpoints);
-      }
-
-      throw err;
-    }
+    await Promise.all(chunk(checkpoints, 1000).map(chunk => insert(chunk)));
   }
 
   /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,11 @@
+export function chunk<T>(array: T[], chunkSize: number) {
+  const chunks = [] as T[][];
+  let index = 0;
+
+  while (index < array.length) {
+    chunks.push(array.slice(index, chunkSize + index));
+    index += chunkSize;
+  }
+
+  return chunks;
+}

--- a/test/unit/utils/helpers.test.ts
+++ b/test/unit/utils/helpers.test.ts
@@ -1,0 +1,14 @@
+import { chunk } from '../../../src/utils/helpers';
+
+describe('chunk', () => {
+  it('should chunk array', () => {
+    const array = [1, 2, 3, 4, 5, 6, 7, 8];
+    const chunked = chunk(array, 3);
+
+    expect(chunked).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8]
+    ]);
+  });
+});


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/168
Closes: https://github.com/checkpoint-labs/checkpoint/issues/185
Closes: https://github.com/checkpoint-labs/checkpoint/issues/200

This PR adds prefetch for events, making it possible to only fetch blocks we know we have blocks for. Prefetch will speed up catching up to latest block (-50) by fetching events from 100 blocks at the time, and storing them in database, from where they are queried by normal indexing process to find events from source contracts. Old unused events are later purged.


## Test plan

You can test it by running it as usual, no extra changes on consumer side should be needed - it should just be much faster at finding new events.
