### PR TITLE
feat: persist templates

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -30,7 +30,7 @@ import {
   singleEntityQueryName,
   getNonNullType
 } from '../utils/graphql';
-import { CheckpointConfig, CheckpointOptions } from '../types';
+import { CheckpointConfig } from '../types';
 import { querySingle, queryMulti, ResolverContext, getNestedResolver } from './resolvers';
 
 /**

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,12 +1,13 @@
 import { Pool as PgPool } from 'pg';
-import type { Logger } from '../utils/logger';
-import type Checkpoint from '../checkpoint';
-import type { AsyncMySqlPool } from '../mysql';
-import type { CheckpointConfig, CheckpointWriters } from '../types';
+import { Logger } from '../utils/logger';
+import Checkpoint from '../checkpoint';
+import { AsyncMySqlPool } from '../mysql';
+import { CheckpointConfig, CheckpointWriters, ContractSourceConfig } from '../types';
 
 type Instance = {
   writer: CheckpointWriters;
   config: CheckpointConfig;
+  getCurrentSources(blockNumber: number): ContractSourceConfig[];
   setLastIndexedBlock(blockNum: number);
   insertCheckpoints(checkpoints: { blockNumber: number; contractAddress: string }[]);
   getWriterParams(): Promise<{

--- a/src/providers/starknet/index.ts
+++ b/src/providers/starknet/index.ts
@@ -180,7 +180,7 @@ export class StarknetProvider extends BaseProvider {
       }
     }
 
-    for (const source of this.instance.config.sources || []) {
+    for (const source of this.instance.getCurrentSources(blockNumber)) {
       let foundContractData = false;
       const contract = validateAndParseAddress(source.contract);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,12 @@ export type DeployTransaction = Transaction & { contract_address: string };
 export type EventsMap = { [key: string]: Event[] };
 export type ParsedEvent = Record<string, any>;
 
+export type TemplateSource = {
+  contractAddress: string;
+  startBlock: number;
+  template: string;
+};
+
 export interface CheckpointOptions {
   // Setting to true will trigger reset of database on config changes.
   resetOnConfigChange?: boolean;

--- a/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`CheckpointsStore createStore should execute correct query 1`] = `
 "create table \`_checkpoints\` (\`id\` varchar(10), \`block_number\` bigint not null, \`contract_address\` varchar(66) not null, primary key (\`id\`));
 drop table if exists \`_metadatas\`;
-create table \`_metadatas\` (\`id\` varchar(20), \`value\` varchar(128) not null, primary key (\`id\`))"
+create table \`_metadatas\` (\`id\` varchar(20), \`value\` varchar(128) not null, primary key (\`id\`));
+drop table if exists \`_template_sources\`;
+create table \`_template_sources\` (\`id\` integer not null primary key autoincrement, \`contract_address\` varchar(66), \`start_block\` bigint not null, \`template\` varchar(128) not null)"
 `;
 
 exports[`CheckpointsStore insertCheckpoints should insert checkpoints 1`] = `


### PR DESCRIPTION
We need to persist templates, otherwise when restarting the server it will continue processing blocks from last indexed block, but with information about executed templates it's likely to omit events.

## Test plan
- Start sx-api for ~100 blocks.
- Log `this.config.sources` here: https://github.com/checkpoint-labs/checkpoint/blob/c5e4deb22462b05b509e917277d11b8e884e988d/src/checkpoint.ts#L309
- Start sx-api without calling .reset (just .start())
- It should log both factory and one space in sources.