### PR TITLE
fix: add missing shebang to cli entrypoint

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import path from 'path';
 import fs from 'fs/promises';
 import process from 'process';


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/239

## Test plan

- Have repo in which you have Checkpoint beta.18 installed.
- In checkpoint repo run `yarn build`.
- Copy `dist/src/bin/index.js` from checkpoint to `node_modules/.bin/checkpoint` (this file should already exist, replace its contents) in other repo.
- Run `yarn checkpoint` in the other repo. It brings up help message.