### PR TITLE
feat: process new sources events in same transaction

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -156,7 +156,7 @@ export default class Checkpoint {
 
     const templateSources = await this.store.getTemplateSources();
     await Promise.all(
-      templateSources.map(source => {
+      templateSources.map(source =>
         this.executeTemplate(
           source.template,
           {
@@ -164,8 +164,8 @@ export default class Checkpoint {
             start: source.startBlock
           },
           false
-        );
-      })
+        )
+      )
     );
 
     const blockNum = await this.getStartBlockNum();


### PR DESCRIPTION
Previously sources added at transaction A would not be processed at that transaction, only when next transaction is processed.

This PR changes this behaviour causing new sources to be processed immediatelly, within the same transaction they were created (assuming start block expects this).