### PR TITLE
fix: handle non-nullable List types

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -194,9 +194,11 @@ export const getNestedResolver = (columnName: string) =>
   };
 
 function getJsonFields(type: GraphQLObjectType) {
-  return Object.values(type.getFields()).filter(
-    field => isListType(field.type) && field.type.ofType instanceof GraphQLScalarType
-  );
+  return Object.values(type.getFields()).filter(field => {
+    const baseType = getNonNullType(field.type);
+
+    return isListType(baseType) && baseType.ofType instanceof GraphQLScalarType;
+  });
 }
 
 function formatItem(item: Record<string, any>, jsonFields: GraphQLField<any, any>[]) {


### PR DESCRIPTION
Allows querying fields like this
```
authenticators: String[]!
```

Can be tested with https://github.com/snapshot-labs/sx-api/pull/186