### PR TITLE
fix: encode JSON fields on load

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -154,7 +154,10 @@ export const codegen = (
     contents += `    const model = new ${modelName}(id);\n`;
     contents += `    model.setExists();\n\n`;
     contents += `    for (const key in entity) {\n`;
-    contents += `      model.set(key, entity[key]);\n`;
+    contents += `      const value = entity[key] !== null && typeof entity[key] === 'object'\n`;
+    contents += `        ? JSON.stringify(entity[key])\n`;
+    contents += `        : entity[key];\n`;
+    contents += `      model.set(key, value);\n`;
     contents += `    }\n\n`;
     contents += `    return model;\n`;
     contents += `  }\n\n`;

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -28,7 +28,10 @@ export class Space extends Model {
     model.setExists();
 
     for (const key in entity) {
-      model.set(key, entity[key]);
+      const value = entity[key] !== null && typeof entity[key] === 'object'
+        ? JSON.stringify(entity[key])
+        : entity[key];
+      model.set(key, value);
     }
 
     return model;
@@ -130,7 +133,10 @@ export class Proposal extends Model {
     model.setExists();
 
     for (const key in entity) {
-      model.set(key, entity[key]);
+      const value = entity[key] !== null && typeof entity[key] === 'object'
+        ? JSON.stringify(entity[key])
+        : entity[key];
+      model.set(key, value);
     }
 
     return model;
@@ -223,7 +229,10 @@ export class Space extends Model {
     model.setExists();
 
     for (const key in entity) {
-      model.set(key, entity[key]);
+      const value = entity[key] !== null && typeof entity[key] === 'object'
+        ? JSON.stringify(entity[key])
+        : entity[key];
+      model.set(key, value);
     }
 
     return model;
@@ -325,7 +334,10 @@ export class Proposal extends Model {
     model.setExists();
 
     for (const key in entity) {
-      model.set(key, entity[key]);
+      const value = entity[key] !== null && typeof entity[key] === 'object'
+        ? JSON.stringify(entity[key])
+        : entity[key];
+      model.set(key, value);
     }
 
     return model;


### PR DESCRIPTION
JSON fields have to be encoded when saving on PostgreSQL. We already encode them when set manually, but don't when we get those values from database on load.

## Test plan
- Use [this PR](https://github.com/snapshot-labs/sx-api/pull/186) with PostgreSQL.
- Link and regenerate models with  `node ../checkpoint/dist/src/bin/index.js generate`. (you need to do it with bin file directly, `yarn checkpoint generate` won't work.