### PR TITLE
fix: make sure data from where clause is complete

### DIFF
--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -72,7 +72,7 @@ export const generateQueryForEntity = (entity: GraphQLObjectType): string => {
   );
 };
 
-export const getNonNullType = (type: GraphQLOutputType): GraphQLOutputType => {
+export const getNonNullType = <T>(type: T): T => {
   if (type instanceof GraphQLNonNull) {
     return type.ofType;
   }


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/258

This PR fixes two issues:
- When querying non-nullable nested field in where prevents crash.
- When using nested where resolve objects and lists of scalars.

## Test plan
Run query like this on sx-api:
```gql
{
  votes(where: {space_: {}}) {
    space {
      id
      metadata {
        id
        name
        executors
      }
    }
  }
}
```