### PR TITLE
fix: handle nested entity id set to null

### DIFF
--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -331,7 +331,7 @@ export class GqlEntityController {
             idField &&
             idField.type instanceof GraphQLNonNull &&
             idField.type.ofType instanceof GraphQLScalarType &&
-            ['String', 'ID'].includes(idField.type.ofType.name)
+            ['String', 'Int', 'ID'].includes(idField.type.ofType.name)
           ) {
             if (level === 0) {
               whereInputConfig.fields[`${field.name}_`] = getWhereType(

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -56,8 +56,6 @@ type WhereResult = {
   orderByValues: Record<string, { value: string }>;
 };
 
-const cache = new Map<string, WhereResult>();
-
 /**
  * Controller for performing actions based on the graphql schema provided to its
  * constructor. It exposes public functions to generate graphql or database
@@ -306,11 +304,11 @@ export class GqlEntityController {
     type: GraphQLObjectType,
     resolver: GraphQLFieldResolver<Parent, Context>
   ): GraphQLFieldConfig<Parent, Context> {
-    const getWhereType = (type: GraphQLObjectType<any, any>, level = 0): WhereResult => {
-      const name = `${type.name}_filter`;
-
-      const cachedValue = cache.get(name);
-      if (cachedValue) return cachedValue;
+    const getWhereType = (
+      nestedType: GraphQLObjectType<any, any>,
+      prefix?: string
+    ): WhereResult => {
+      const name = prefix ? `${prefix}_${nestedType.name}_filter` : `${nestedType.name}_filter`;
 
       const orderByValues = {};
       const whereInputConfig: GraphQLInputObjectTypeConfig = {
@@ -318,13 +316,13 @@ export class GqlEntityController {
         fields: {}
       };
 
-      this.getTypeFields(type).forEach(field => {
+      this.getTypeFields(nestedType).forEach(field => {
         // all field types in a where input variable must be optional
         // so we try to extract the non null type here.
         let nonNullFieldType = getNonNullType(field.type);
 
         if (nonNullFieldType instanceof GraphQLObjectType) {
-          const fields = type.getFields();
+          const fields = nestedType.getFields();
           const idField = fields['id'];
 
           if (
@@ -333,10 +331,10 @@ export class GqlEntityController {
             idField.type.ofType instanceof GraphQLScalarType &&
             ['String', 'Int', 'ID'].includes(idField.type.ofType.name)
           ) {
-            if (level === 0) {
+            if (!prefix) {
               whereInputConfig.fields[`${field.name}_`] = getWhereType(
                 nonNullFieldType,
-                level + 1
+                nestedType.name
               ).where;
             }
 
@@ -394,8 +392,6 @@ export class GqlEntityController {
         where: { type: new GraphQLInputObjectType(whereInputConfig) },
         orderByValues
       };
-
-      cache.set(name, result);
 
       return result;
     };

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -153,6 +153,7 @@ export async function querySingle(
 
   const currentValue = parent?.[info.fieldName];
 
+  if (currentValue === null) return null;
   const alreadyResolvedInParent = typeof currentValue === 'object';
   if (alreadyResolvedInParent) {
     return formatItem(currentValue, jsonFields);


### PR DESCRIPTION
Depends on: https://github.com/checkpoint-labs/checkpoint/pull/268
Addresses: https://github.com/checkpoint-labs/checkpoint/pull/268#issuecomment-1748812601

If nullable entity type's ID field is set to null we should return null on entity.

I'm not sure if it fixed issue with `The loader.load() function must be called with a value, but got: undefined.` as I couldn't find a way to reproduce.