### PR TITLE
fix: select checkpoint blocks by distinct

### DIFF
--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -233,7 +233,7 @@ export class CheckpointsStore {
     limit = 15
   ): Promise<number[]> {
     const result = await this.knex
-      .select(Fields.Checkpoints.BlockNumber)
+      .distinct(Fields.Checkpoints.BlockNumber)
       .from(Table.Checkpoints)
       .where(Fields.Checkpoints.BlockNumber, '>=', block)
       .whereIn(Fields.Checkpoints.ContractAddress, contracts)


### PR DESCRIPTION
If there are multiple contracts checkpointed at same block, this block can then be processed multiple times causing issues.