### PR TITLE
fix: start prefetch on last seeded block

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -281,13 +281,16 @@ export default class Checkpoint {
 
     const checkpoints: CheckpointRecord[] = [];
 
+    let finalBlock = 0;
     checkpointBlocks.forEach(cp => {
       cp.blocks.forEach(blockNumber => {
+        finalBlock = Math.max(finalBlock, blockNumber);
         checkpoints.push({ blockNumber, contractAddress: cp.contract });
       });
     });
 
     await this.store.insertCheckpoints(checkpoints);
+    await this.store.setMetadata(MetadataId.LastPrefetchedBlock, finalBlock);
   }
 
   public async setLastIndexedBlock(block: number) {


### PR DESCRIPTION
Currently when using seed checkpoints main loop will start syncing from those seeded blocks, but optimistic loop will prefetch block starting with star block, ignoring all seeds.

This PR addresses it so LastPrefetchedBlock will be adjusted when `seedCheckpoints` is called.