### PR TITLE
feat: add support for non-derived one-to-many relations

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -13,7 +13,7 @@ import {
 } from 'graphql';
 import pluralize from 'pluralize';
 import { GqlEntityController } from './graphql/controller';
-import { extendSchema } from './utils/graphql';
+import { extendSchema, getDerivedFromDirective } from './utils/graphql';
 import { CheckpointConfig } from './types';
 
 type TypeInfo = {
@@ -151,7 +151,11 @@ export const codegen = (
     contents += `    super(${modelName}.tableName);\n\n`;
     typeFields.forEach(field => {
       const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
-      if (isListType(fieldType) && fieldType.ofType instanceof GraphQLObjectType) {
+      if (
+        isListType(fieldType) &&
+        fieldType.ofType instanceof GraphQLObjectType &&
+        getDerivedFromDirective(field)
+      ) {
         return;
       }
 
@@ -180,7 +184,11 @@ export const codegen = (
 
     typeFields.forEach(field => {
       const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
-      if (isListType(fieldType) && fieldType.ofType instanceof GraphQLObjectType) {
+      if (
+        isListType(fieldType) &&
+        fieldType.ofType instanceof GraphQLObjectType &&
+        getDerivedFromDirective(field)
+      ) {
         return;
       }
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -28,7 +28,8 @@ import {
   generateQueryForEntity,
   multiEntityQueryName,
   singleEntityQueryName,
-  getNonNullType
+  getNonNullType,
+  getDerivedFromDirective
 } from '../utils/graphql';
 import { CheckpointConfig } from '../types';
 import { querySingle, queryMulti, ResolverContext, getNestedResolver } from './resolvers';
@@ -216,7 +217,13 @@ export class GqlEntityController {
 
         this.getTypeFields(type).forEach(field => {
           const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
-          if (isListType(fieldType) && fieldType.ofType instanceof GraphQLObjectType) return;
+          if (
+            isListType(fieldType) &&
+            fieldType.ofType instanceof GraphQLObjectType &&
+            getDerivedFromDirective(field)
+          ) {
+            return;
+          }
           const sqlType = this.getSqlType(field.type);
 
           let column =

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,10 +1,10 @@
 import {
   GraphQLObjectType,
-  GraphQLOutputType,
   GraphQLNonNull,
   isLeafType,
   isListType,
-  GraphQLScalarType
+  GraphQLScalarType,
+  GraphQLField
 } from 'graphql';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import pluralize from 'pluralize';
@@ -78,4 +78,9 @@ export const getNonNullType = <T>(type: T): T => {
   }
 
   return type;
+};
+
+export const getDerivedFromDirective = (field: GraphQLField<any, any>) => {
+  const directives = field.astNode?.directives ?? [];
+  return directives.find(dir => dir.name.value === 'derivedFrom');
 };


### PR DESCRIPTION
Currently you can define one-to-many relations using @derivedFrom directive. Using it the field on the entity is just virtual field that gets filled in at query time using lookup on the derived entity's column.

This PR adds support for non-derived one-to-many relations - this field needs to be filled in by writers to be usable. You specify ID's of referenced entity and those will be filled in with full object at query time.