### PR TITLE
feat: prefetch blocks by targetting contracts

### DIFF
--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -10,7 +10,7 @@ type Instance = {
   config: CheckpointConfig;
   getCurrentSources(blockNumber: number): ContractSourceConfig[];
   setLastIndexedBlock(blockNum: number);
-  insertCheckpoints(checkpoints: { blockNumber: number; contractAddress: string }[]);
+  insertCheckpoints(checkpoints: CheckpointRecord[]);
   getWriterParams(): Promise<{
     instance: Checkpoint;
     mysql: AsyncMySqlPool;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,7 +21,6 @@ export const contractTemplateSchema = z.object({
 export const checkpointConfigSchema = z.object({
   network_node_url: z.string().url(),
   optimistic_indexing: z.boolean().optional(),
-  disable_checkpoints: z.boolean().optional(),
   decimal_types: z
     .record(
       z.object({

--- a/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
@@ -4,9 +4,7 @@ exports[`CheckpointsStore createStore should execute correct query 1`] = `
 "create table \`_checkpoints\` (\`id\` varchar(10), \`block_number\` bigint not null, \`contract_address\` varchar(66) not null, primary key (\`id\`));
 create index \`_checkpoints_block_number_index\` on \`_checkpoints\` (\`block_number\`);
 create index \`_checkpoints_contract_address_index\` on \`_checkpoints\` (\`contract_address\`);
-drop table if exists \`_metadatas\`;
 create table \`_metadatas\` (\`id\` varchar(20), \`value\` varchar(128) not null, primary key (\`id\`));
-drop table if exists \`_template_sources\`;
 create table \`_template_sources\` (\`id\` integer not null primary key autoincrement, \`contract_address\` varchar(66), \`start_block\` bigint not null, \`template\` varchar(128) not null)"
 `;
 


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/pitches/issues/75

This PR replaces old prefetch with new system that will load only events from contracts we are interested in.

This makes initial sync much faster (5 minutes instead of couple hours).

### Test plan

- Link this PR in `sx-monorepo` (also link `graphql` from `node_modules/graphql`) and build.
- Previous step might not work right away, if you get missing packages error when starting server nuke `node_modules` in both repos, reinstall and relink again - super inconsistent.
- Add `checkpoint.resetMetadata` before `reset` call.
- Start sx-api `NETWORK_NODE_URL=https://starknet-sepolia.infura.io/v3/AAAA NETWORK=SN_SEPOLIA yarn dev`
- Once synced (should take couple of minutes) check responses for some requests (for example all spaces with proposal/vote counts) and compare it with https://testnet-api-1.snapshotx.xyz/