### PR TITLE
chore: make logs less verbose in non-optimistic mode

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -372,11 +372,13 @@ export default class Checkpoint {
 
       return this.next(nextBlockNumber);
     } catch (err) {
-      if (this.config.optimistic_indexing && err instanceof BlockNotFoundError) {
-        try {
-          await this.networkProvider.processPool(blockNum);
-        } catch (err) {
-          this.log.error({ blockNumber: blockNum, err }, 'error occurred during pool processing');
+      if (err instanceof BlockNotFoundError) {
+        if (this.config.optimistic_indexing) {
+          try {
+            await this.networkProvider.processPool(blockNum);
+          } catch (err) {
+            this.log.error({ blockNumber: blockNum, err }, 'error occurred during pool processing');
+          }
         }
       } else {
         this.log.error({ blockNumber: blockNum, err }, 'error occurred during block processing');


### PR DESCRIPTION
Previously if optimistic indexing was not enabled every time
block is not found message would be displayed at ERROR level.

This PR prevents it from happening, only single info message
will be emitted.
