### PR TITLE
fix: do not apply block range filter on internal tables

### DIFF
--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -49,6 +49,8 @@ export enum MetadataId {
   SchemaVersion = 'schema_version'
 }
 
+export const INTERNAL_TABLES = Object.values(Table);
+
 const CheckpointIdSize = 10;
 
 /**

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,7 +1,17 @@
 import pluralize from 'pluralize';
+import { Knex } from 'knex';
+import { INTERNAL_TABLES } from '../stores/checkpoints';
 
 export const getTableName = (name: string) => {
   if (name === '_metadata') return '_metadatas';
 
   return pluralize(name);
 };
+
+export function applyBlockFilter(query: Knex.QueryBuilder, tableName: string, block?: number) {
+  if (INTERNAL_TABLES.includes(tableName)) return query;
+
+  return block !== undefined
+    ? query.andWhereRaw(`${tableName}.block_range @> int8(??)`, [block])
+    : query.andWhereRaw(`upper_inf(${tableName}.block_range)`);
+}

--- a/test/unit/utils/database.test.ts
+++ b/test/unit/utils/database.test.ts
@@ -1,0 +1,57 @@
+import knex from 'knex';
+import { getTableName, applyBlockFilter } from '../../../src/utils/database';
+
+const mockKnex = knex({
+  client: 'sqlite3',
+  connection: {
+    filename: ':memory:'
+  },
+  useNullAsDefault: true
+});
+
+afterAll(async () => {
+  await mockKnex.destroy();
+});
+
+describe('getTableName', () => {
+  it.each([
+    ['table', 'tables'],
+    ['user', 'users'],
+    ['post', 'posts'],
+    ['space', 'spaces'],
+    ['vote', 'votes'],
+    ['comment', 'comments']
+  ])('should return pluralized table name', (name, expected) => {
+    expect(getTableName(name)).toEqual(expected);
+  });
+
+  it('should return hardcoded table name for metadata', () => {
+    expect(getTableName('_metadata')).toEqual('_metadatas');
+  });
+});
+
+describe('applyBlockFilter', () => {
+  it('should not apply filter for internal tables', () => {
+    const query = mockKnex.select('*').from('_metadatas');
+
+    const result = applyBlockFilter(query, '_metadatas', 123);
+
+    expect(result.toString()).toBe('select * from `_metadatas`');
+  });
+
+  it('should apply capped block filter if block is provided', () => {
+    const query = mockKnex.select('*').from('posts');
+
+    const result = applyBlockFilter(query, 'posts', 123);
+
+    expect(result.toString()).toBe('select * from `posts` where posts.block_range @> int8(123)');
+  });
+
+  it('should apply upper_inf block filter if block is not provided', () => {
+    const query = mockKnex.select('*').from('posts');
+
+    const result = applyBlockFilter(query, 'posts');
+
+    expect(result.toString()).toBe('select * from `posts` where upper_inf(posts.block_range)');
+  });
+});


### PR DESCRIPTION
This commit also refactors out applyBlockFilter helper into database utils to avoid repetition.

Closes: https://github.com/checkpoint-labs/checkpoint/issues/301

### Test plan

Run query like this:
```gql
query ($checkpointId: ID!, $metadataId: ID!) {
  spaces(block: 18407) {
    id
  }
  _checkpoints {
    id
  }
  _metadatas {
    id
  }
  _checkpoint(id: $checkpointId) {
    id
  }
  _metadata(id: $metadataId) {
    id
  }
}
```
It works without crashing.