### PR TITLE
fix: deduplicate checkpoints

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -336,7 +336,7 @@ export default class Checkpoint {
       this.preloadStep = Math.max(BLOCK_RELOAD_MIN_RANGE, this.preloadStep + increase);
 
       if (checkpoints.length > 0) {
-        this.preloadedBlocks = checkpoints.map(cp => cp.blockNumber).sort();
+        this.preloadedBlocks = [...new Set(checkpoints.map(cp => cp.blockNumber).sort())];
         return this.preloadedBlocks.shift() as number;
       }
 


### PR DESCRIPTION
If there are multiple events in single block we should only add one entry
into preloadBlocks. Otherwise it will cause `next` to be called multiple times
for the same block.
