### PR TITLE
feat: filter starknet events by event names

### DIFF
--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -343,7 +343,8 @@ export class StarknetProvider extends BaseProvider {
   async getCheckpointsRangeForAddress(
     fromBlock: number,
     toBlock: number,
-    address: string
+    address: string,
+    eventNames: string[]
   ): Promise<CheckpointRecord[]> {
     let events: Event[] = [];
 
@@ -353,6 +354,7 @@ export class StarknetProvider extends BaseProvider {
         from_block: { block_number: fromBlock },
         to_block: { block_number: toBlock },
         address: address,
+        keys: [eventNames.map(name => `0x${hash.starknetKeccak(name).toString(16)}`)],
         chunk_size: 1000,
         continuation_token: continuationToken
       });
@@ -375,7 +377,8 @@ export class StarknetProvider extends BaseProvider {
       const addressEvents = await this.getCheckpointsRangeForAddress(
         fromBlock,
         toBlock,
-        source.contract
+        source.contract,
+        source.events.map(event => event.name)
       );
       events = events.concat(addressEvents);
     }


### PR DESCRIPTION
Closes: https://github.com/checkpoint-labs/checkpoint/issues/308

In case of contracts that have lots of activity overall, but we only care about few events we should filter events by keys as well. This way we are not processing blocks that do not contain blocks that we are interested with.

## Test plan

1. Test with https://github.com/snapshot-labs/delegates-api/commits/fabien/multi-tokens/
2. It should be quick to sync (I only tested with NSTR token so it's quicker, currently testing with STRK, but it has lots of activity we are targeting so it won't be much faster).