### PR TITLE
fix: restore preloaded block on error

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -347,14 +347,14 @@ export default class Checkpoint {
   }
 
   private async next(blockNum: number) {
-    let checkpointBlock;
+    let checkpointBlock, preloadedBlock;
     if (!this.config.tx_fn && !this.config.global_events) {
       checkpointBlock = await this.getNextCheckpointBlock(blockNum);
 
       if (checkpointBlock) {
         blockNum = checkpointBlock;
       } else if (blockNum <= this.preloadEndBlock) {
-        const preloadedBlock = await this.preload(blockNum);
+        preloadedBlock = await this.preload(blockNum);
         blockNum = preloadedBlock || this.preloadEndBlock + 1;
       }
     }
@@ -388,6 +388,10 @@ export default class Checkpoint {
 
       if (checkpointBlock && this.cpBlocksCache) {
         this.cpBlocksCache.unshift(checkpointBlock);
+      }
+
+      if (preloadedBlock && this.preloadedBlocks) {
+        this.preloadedBlocks.unshift(preloadedBlock);
       }
 
       await sleep(this.opts?.fetchInterval || DEFAULT_FETCH_INTERVAL);


### PR DESCRIPTION
When processing preloaded block and error happens we need to put it back into preloadedBlocks array (similar as with checkpoint block).

### Test plan

- Put `throw` in random writer (that isn't caught).
- It should keep retrying processing this block instead of progressing further.