### PR TITLE
feat: add filters for list types

### DIFF
--- a/src/knex.ts
+++ b/src/knex.ts
@@ -4,7 +4,7 @@ import { ConnectionString } from 'connection-string';
 
 export type KnexType =
   | {
-      name: 'integer' | 'bigint' | 'boolean' | 'text' | 'json';
+      name: 'integer' | 'bigint' | 'boolean' | 'text' | 'json' | 'jsonb';
     }
   | {
       name: 'decimal';

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -11,6 +11,7 @@ exports[`GqlEntityController createEntityStores should work 1`] = `
 create table \`votes\` (\`uid\` char(36) default (lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))), \`block_range\` int8range not null, \`id\` integer not null, \`name\` varchar(256), \`authenticators\` json, \`big_number\` bigint, \`decimal\` float, \`big_decimal\` float, primary key (\`uid\`));
 create index \`votes_id_index\` on \`votes\` (\`id\`);
 create index \`votes_name_index\` on \`votes\` (\`name\`);
+create index \`votes_authenticators_index\` on \`votes\` (\`authenticators\`);
 create index \`votes_big_number_index\` on \`votes\` (\`big_number\`);
 create index \`votes_decimal_index\` on \`votes\` (\`decimal\`);
 create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
@@ -55,6 +56,10 @@ input Vote_filter {
   name_not: String
   name_in: [String]
   name_not_in: [String]
+  authenticators: [String]
+  authenticators_not: [String]
+  authenticators_contains: [String]
+  authenticators_not_contains: [String]
 }"
 `;
 


### PR DESCRIPTION
## Summary

This commit adds support for filters for list of scalar types:
- list
- list_not
- list_contains
- list_not_contains

Those filters are implemented using in PostgreSQL and only available on JSONB so we changed column type for those fields.

This will allow us to implement https://github.com/snapshot-labs/workflow/issues/254 again.

## Test plan:

Run sx-api on Sepolia with default start index for a bit to get some data (1 minute should be enough), run following queries:

```gql
{
  spaces(
    where: {
      authenticators: [
        "0x2b63a8a92b7c67484ab99c4307c7db41b15b9a3c33359cd2b2459fd7f543a9c"
      ]
    }
  ) {
    id
    authenticators
  }
}
```

```gql
{
  spaces(
    where: {
      authenticators_not: [
        "0x2b63a8a92b7c67484ab99c4307c7db41b15b9a3c33359cd2b2459fd7f543a9c"
      ]
    }
  ) {
    id
    authenticators
  }
}
```

```gql
{
  spaces(
    where: {
      authenticators_contains: [
        "0x53d98050a9738da0eac7498d909ea03f6eb03d07fb95877b54ff8acf7712276",
        "0x2b63a8a92b7c67484ab99c4307c7db41b15b9a3c33359cd2b2459fd7f543a9c"
      ]
    }
  ) {
    id
    authenticators
  }
}
```

```gql
{
  spaces(
    where: {
      authenticators_not_contains: [
        "0x2b63a8a92b7c67484ab99c4307c7db41b15b9a3c33359cd2b2459fd7f543a9c"
      ]
    }
  ) {
    id
    authenticators
  }
}
```

They work as you expect them.