### PR TITLE
fix: clear blocks on reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.42",
+  "version": "0.1.0-beta.43",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -202,6 +202,7 @@ export default class Checkpoint {
     await this.store.createStore();
     await this.store.setMetadata(MetadataId.LastIndexedBlock, 0);
     await this.store.setMetadata(MetadataId.SchemaVersion, SCHEMA_VERSION);
+    await this.store.removeBlocks();
 
     await this.entityController.createEntityStores(this.knex);
   }

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -170,6 +170,10 @@ export class CheckpointsStore {
     await this.createStore();
   }
 
+  public async removeBlocks(): Promise<void> {
+    return this.knex(Table.Blocks).del();
+  }
+
   public async getBlockHash(blockNumber: number): Promise<string | null> {
     const blocks = await this.knex
       .select(Fields.Blocks.Hash)


### PR DESCRIPTION
When we reset we will visit old blocks again so we need to clear previously stored ones to avoid conflicts.