### PR TITLE
fix: initialize arrays to string value

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -74,7 +74,7 @@ export const getTypeInfo = (
     const nonNullNestedType =
       type.ofType instanceof GraphQLNonNull ? type.ofType.ofType : type.ofType;
 
-    return { type: `${getTypeInfo(nonNullNestedType, decimalTypes).type}[]`, initialValue: [] };
+    return { type: `${getTypeInfo(nonNullNestedType, decimalTypes).type}[]`, initialValue: '[]' };
   }
 
   throw new Error('Unknown type');

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -16,8 +16,8 @@ export class Space extends Model {
     this.initialSet('voting_delay', 0);
     this.initialSet('proposal_threshold', 0);
     this.initialSet('quorum', 0);
-    this.initialSet('strategies', []);
-    this.initialSet('strategies_nonnull', []);
+    this.initialSet('strategies', "[]");
+    this.initialSet('strategies_nonnull', "[]");
   }
 
   static async loadEntity(id) {
@@ -217,8 +217,8 @@ export class Space extends Model {
     this.initialSet('voting_delay', 0);
     this.initialSet('proposal_threshold', 0);
     this.initialSet('quorum', 0);
-    this.initialSet('strategies', []);
-    this.initialSet('strategies_nonnull', []);
+    this.initialSet('strategies', "[]");
+    this.initialSet('strategies_nonnull', "[]");
   }
 
   static async loadEntity(id: string): Promise<Space | null> {

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -100,9 +100,9 @@ describe('getInitialValue', () => {
     expect(getInitialValue(proposalFields['active'].type)).toBe(false);
   });
 
-  it('should return empty array for List types', () => {
-    expect(getInitialValue(spaceFields['strategies'].type)).toEqual([]);
-    expect(getInitialValue(spaceFields['strategies_nonnull'].type)).toEqual([]);
+  it('should return stringified empty array for List types', () => {
+    expect(getInitialValue(spaceFields['strategies'].type)).toEqual('[]');
+    expect(getInitialValue(spaceFields['strategies_nonnull'].type)).toEqual('[]');
   });
 
   it('should return empty string for object types', () => {


### PR DESCRIPTION
Arrays are stored as strings in the database so we have to initialize them as such as well.