### PR TITLE
feat: add indexer to metadata

### DIFF
--- a/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/stores/__snapshots__/checkpoints.test.ts.snap
@@ -1,26 +1,160 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckpointsStore createStore should execute correct query 1`] = `
-"create table \`_blocks\` (\`block_number\` bigint, \`hash\` varchar(255) not null, primary key (\`block_number\`));
-create unique index \`_blocks_hash_unique\` on \`_blocks\` (\`hash\`);
-create table \`_checkpoints\` (\`id\` varchar(10), \`block_number\` bigint not null, \`contract_address\` varchar(66) not null, primary key (\`id\`));
-create index \`_checkpoints_block_number_index\` on \`_checkpoints\` (\`block_number\`);
-create index \`_checkpoints_contract_address_index\` on \`_checkpoints\` (\`contract_address\`);
-create table \`_metadatas\` (\`id\` varchar(20), \`value\` varchar(128) not null, primary key (\`id\`));
-create table \`_template_sources\` (\`id\` integer not null primary key autoincrement, \`contract_address\` varchar(66), \`start_block\` bigint not null, \`template\` varchar(128) not null)"
-`;
-
-exports[`CheckpointsStore insertCheckpoints should insert checkpoints 1`] = `
+exports[`CheckpointsStore blocks should remove blocks 1`] = `
 [
   {
     "block_number": 5000,
-    "contract_address": "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
-    "id": "a739beda26",
+    "hash": "0x0",
+    "indexer": "default",
   },
   {
-    "block_number": 123222,
-    "contract_address": "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
-    "id": "d2b8dcc2b5",
+    "block_number": 5001,
+    "hash": "0x1",
+    "indexer": "default",
+  },
+]
+`;
+
+exports[`CheckpointsStore blocks should set block hash 1`] = `
+[
+  {
+    "block_number": 5000,
+    "hash": "0x0",
+    "indexer": "default",
+  },
+  {
+    "block_number": 5001,
+    "hash": "0x1",
+    "indexer": "default",
+  },
+  {
+    "block_number": 5000,
+    "hash": "0xa",
+    "indexer": "OTHER",
+  },
+]
+`;
+
+exports[`CheckpointsStore checkpoints should insert checkpoints 1`] = `
+[
+  {
+    "block_number": 5000,
+    "contract_address": "0x01",
+    "id": "6f1246bdea",
+    "indexer": "default",
+  },
+  {
+    "block_number": 9000,
+    "contract_address": "0x02",
+    "id": "92df4d22e3",
+    "indexer": "default",
+  },
+  {
+    "block_number": 11000,
+    "contract_address": "0x01",
+    "id": "24a44a0b0b",
+    "indexer": "default",
+  },
+]
+`;
+
+exports[`CheckpointsStore createStore should execute correct query 1`] = `
+"create table \`_blocks\` (\`indexer\` varchar(255) not null, \`block_number\` bigint, \`hash\` varchar(255) not null, primary key (\`indexer\`, \`block_number\`));
+create table \`_checkpoints\` (\`id\` varchar(10), \`indexer\` varchar(255) not null, \`block_number\` bigint not null, \`contract_address\` varchar(66) not null, primary key (\`id\`, \`indexer\`));
+create index \`_checkpoints_block_number_index\` on \`_checkpoints\` (\`block_number\`);
+create index \`_checkpoints_contract_address_index\` on \`_checkpoints\` (\`contract_address\`);
+create table \`_metadatas\` (\`id\` varchar(20), \`indexer\` varchar(255) not null, \`value\` varchar(128) not null, primary key (\`id\`, \`indexer\`));
+create table \`_template_sources\` (\`indexer\` varchar(255) not null, \`contract_address\` varchar(66), \`start_block\` bigint not null, \`template\` varchar(128) not null)"
+`;
+
+exports[`CheckpointsStore metadata should set metadata 1`] = `
+[
+  {
+    "id": "key",
+    "indexer": "default",
+    "value": "default_value",
+  },
+  {
+    "id": "number_key",
+    "indexer": "default",
+    "value": "1111",
+  },
+  {
+    "id": "key",
+    "indexer": "OTHER",
+    "value": "other_value",
+  },
+]
+`;
+
+exports[`CheckpointsStore removeFutureData should remove future data 1`] = `
+[
+  {
+    "block_number": 5000,
+    "contract_address": "0x01",
+    "id": "6f1246bdea",
+    "indexer": "default",
+  },
+  {
+    "block_number": 9000,
+    "contract_address": "0x02",
+    "id": "92df4d22e3",
+    "indexer": "default",
+  },
+  {
+    "block_number": 11000,
+    "contract_address": "0x01",
+    "id": "24a44a0b0b",
+    "indexer": "OTHER",
+  },
+]
+`;
+
+exports[`CheckpointsStore template sources should insert template sources 1`] = `
+[
+  {
+    "contract_address": "0x01",
+    "indexer": "default",
+    "start_block": 1000,
+    "template": "Template1",
+  },
+  {
+    "contract_address": "0x01",
+    "indexer": "default",
+    "start_block": 2000,
+    "template": "Template1",
+  },
+  {
+    "contract_address": "0x02",
+    "indexer": "default",
+    "start_block": 2100,
+    "template": "Template3",
+  },
+  {
+    "contract_address": "0x01",
+    "indexer": "OTHER",
+    "start_block": 50,
+    "template": "Template1",
+  },
+]
+`;
+
+exports[`CheckpointsStore template sources should retrieve template sources 1`] = `
+[
+  {
+    "contractAddress": "0x01",
+    "startBlock": 1000,
+    "template": "Template1",
+  },
+  {
+    "contractAddress": "0x01",
+    "startBlock": 2000,
+    "template": "Template1",
+  },
+  {
+    "contractAddress": "0x02",
+    "startBlock": 2100,
+    "template": "Template3",
   },
 ]
 `;

--- a/test/unit/stores/checkpoints.test.ts
+++ b/test/unit/stores/checkpoints.test.ts
@@ -1,6 +1,6 @@
 import knex from 'knex';
 import { mockDeep } from 'jest-mock-extended';
-import { CheckpointsStore } from '../../../src/stores/checkpoints';
+import { CheckpointsStore, MetadataId, Table } from '../../../src/stores/checkpoints';
 import { Logger } from '../../../src/utils/logger';
 
 function createMockLogger() {
@@ -10,6 +10,8 @@ function createMockLogger() {
 }
 
 describe('CheckpointsStore', () => {
+  const INDEXER = 'default';
+
   const mockKnex = knex({
     client: 'sqlite3',
     connection: {
@@ -33,22 +35,190 @@ describe('CheckpointsStore', () => {
     });
   });
 
-  describe('insertCheckpoints', () => {
-    it('should insert checkpoints', async () => {
-      const checkpoints = [
+  describe('removeFutureData', () => {
+    afterAll(async () => {
+      await store.resetStore();
+    });
+
+    it('should remove future data', async () => {
+      await store.setMetadata(INDEXER, MetadataId.LastIndexedBlock, 11001);
+      await store.setMetadata('OTHER', MetadataId.LastIndexedBlock, 11001);
+
+      await store.insertCheckpoints(INDEXER, [
         {
-          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+          contractAddress: '0x01',
           blockNumber: 5000
         },
         {
-          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
-          blockNumber: 123222
+          contractAddress: '0x02',
+          blockNumber: 9000
+        },
+        {
+          contractAddress: '0x01',
+          blockNumber: 11000
+        }
+      ]);
+      await store.insertCheckpoints('OTHER', [
+        {
+          contractAddress: '0x01',
+          blockNumber: 11000
+        }
+      ]);
+
+      await store.removeFutureData(INDEXER, 10000);
+
+      const defaultLastIndexedBlock = await store.getMetadataNumber(
+        INDEXER,
+        MetadataId.LastIndexedBlock
+      );
+      expect(defaultLastIndexedBlock).toEqual(10000);
+
+      const otherLastIndexedBlock = await store.getMetadataNumber(
+        'OTHER',
+        MetadataId.LastIndexedBlock
+      );
+      expect(otherLastIndexedBlock).toEqual(11001);
+
+      const result = await mockKnex.select('*').from(Table.Checkpoints);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('blocks', () => {
+    afterAll(async () => {
+      await store.resetStore();
+    });
+
+    it('should set block hash', async () => {
+      await store.setBlockHash(INDEXER, 5000, '0x0');
+      await store.setBlockHash(INDEXER, 5001, '0x1');
+      await store.setBlockHash('OTHER', 5000, '0xa');
+
+      const result = await mockKnex.select('*').from(Table.Blocks);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should retrieve block hash', async () => {
+      const result = await store.getBlockHash(INDEXER, 5000);
+      expect(result).toEqual('0x0');
+    });
+
+    it('should return null if retrieving non-existent block hash', async () => {
+      const result = await store.getBlockHash(INDEXER, 6000);
+      expect(result).toBeNull();
+    });
+
+    it('should remove blocks', async () => {
+      await store.removeBlocks('OTHER');
+
+      const result = await mockKnex.select('*').from(Table.Blocks);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('metadata', () => {
+    afterAll(async () => {
+      await store.resetStore();
+    });
+
+    it('should set metadata', async () => {
+      await store.setMetadata(INDEXER, 'key', 'default_value');
+      await store.setMetadata(INDEXER, 'number_key', 1111);
+      await store.setMetadata('OTHER', 'key', 'other_value');
+
+      const result = await mockKnex.select('*').from(Table.Metadata);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should retrieve metadata', async () => {
+      const result = await store.getMetadata(INDEXER, 'key');
+      expect(result).toEqual('default_value');
+    });
+
+    it('should retrieve metadata as number', async () => {
+      const result = await store.getMetadataNumber(INDEXER, 'number_key');
+      expect(result).toEqual(1111);
+    });
+
+    it('should return null if retrieving non-existent metadata value', async () => {
+      const result = await store.getMetadata(INDEXER, 'non_existent_key');
+      expect(result).toBeNull();
+    });
+
+    it('should return null if retrieving non-existent metadata value as number', async () => {
+      const result = await store.getMetadataNumber(INDEXER, 'non_existent_key');
+      expect(result).toBeNull();
+    });
+
+    it('should update metadata', async () => {
+      await store.setMetadata(INDEXER, 'key', 'new_value');
+      const result = await store.getMetadata(INDEXER, 'key');
+      expect(result).toEqual('new_value');
+    });
+  });
+
+  describe('checkpoints', () => {
+    const CONTRACT_A = '0x01';
+    const CONTRACT_B = '0x02';
+
+    afterAll(async () => {
+      await store.resetStore();
+    });
+
+    it('should insert checkpoints', async () => {
+      const checkpoints = [
+        {
+          contractAddress: CONTRACT_A,
+          blockNumber: 5000
+        },
+        {
+          contractAddress: CONTRACT_B,
+          blockNumber: 9000
+        },
+        {
+          contractAddress: CONTRACT_A,
+          blockNumber: 11000
         }
       ];
 
-      await store.insertCheckpoints(checkpoints);
+      await store.insertCheckpoints(INDEXER, checkpoints);
 
-      const result = await mockKnex.select('*').from('_checkpoints');
+      const result = await mockKnex.select('*').from(Table.Checkpoints);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should return next checkpoint blocks', async () => {
+      let result = await store.getNextCheckpointBlocks(INDEXER, 4000, [CONTRACT_A, CONTRACT_B]);
+      expect(result).toEqual([5000, 9000, 11000]);
+
+      result = await store.getNextCheckpointBlocks(INDEXER, 7000, [CONTRACT_A, CONTRACT_B]);
+      expect(result).toEqual([9000, 11000]);
+
+      result = await store.getNextCheckpointBlocks(INDEXER, 4000, [CONTRACT_B]);
+      expect(result).toEqual([9000]);
+    });
+  });
+
+  describe('template sources', () => {
+    const CONTRACT_A = '0x01';
+    const CONTRACT_B = '0x02';
+
+    afterAll(async () => {
+      await store.resetStore();
+    });
+
+    it('should insert template sources', async () => {
+      await store.insertTemplateSource(INDEXER, CONTRACT_A, 1000, 'Template1');
+      await store.insertTemplateSource(INDEXER, CONTRACT_A, 2000, 'Template1');
+      await store.insertTemplateSource(INDEXER, CONTRACT_B, 2100, 'Template3');
+      await store.insertTemplateSource('OTHER', CONTRACT_A, 50, 'Template1');
+
+      const result = await mockKnex.select('*').from(Table.TemplateSources);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should retrieve template sources', async () => {
+      const result = await store.getTemplateSources(INDEXER);
       expect(result).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
With support for multiple indexers in single Checkpoint instance we have to accomodate for those in our database.
This commit makes necessary changes in our metadata store.

Currently checkpoint still supports single indexer, but now metadata can accomodate it.

## Test plan

1. Run checkpoint-template with this PR (you need to call `resetMetadata` before `reset`).
2. Run this query.
3. All looks good (we don't expose indexer in metadata on GraphQL yet, next PR).

```gql
{
  posts {
    id
    content
    tag
    tx_hash
    created_at_block
  }
  _metadatas {
    id
    value
  }
}
```