### PR TITLE
fix: read type on-demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/sx-monorepo/issues/997

Refactors: https://github.com/checkpoint-labs/checkpoint/pull/319, https://github.com/checkpoint-labs/checkpoint/pull/321

We can't precompute type because it's impossible to easily figure out what part of where filter is type and what is operator.

For example max_end_gte should be (max_end, gte), but authenticators_not_containts should be (authenticators, not_contains) so it can't be done with simple split, because pivot is moving around.

## Test plan

With sx-api run this query, no errors show up.

```gql
{
  proposals(
    where: {
      cancelled: false
      space_in: [
        "0x03ced313394107c43a2f36b63262c00a6422231ac229dc4cedd0d9928d8c3c5f"
      ]
      metadata_: { title_contains_nocase: "" }
      max_end_gt: 0
    }
  ) {
    id
  }
  spaces(
    where: {
      authenticators_contains: [
        "0x47ee3743ce7ad0ffcdb1ba51c9730a77cafd0ca51539714e711258f86c9f8af"
      ]
    }
  ) {
    authenticators
  }
}
```