### PR TITLE
refactor: move lifecycle logic to per-indexer container

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -4,37 +4,22 @@ import { Knex } from 'knex';
 import { Pool as PgPool } from 'pg';
 import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
 import { GqlEntityController } from './graphql/controller';
-import { CheckpointRecord, CheckpointsStore, MetadataId } from './stores/checkpoints';
-import { BaseIndexer, BlockNotFoundError, ReorgDetectedError } from './providers';
+import { CheckpointsStore } from './stores/checkpoints';
+import { BaseIndexer } from './providers';
 import { createLogger, Logger, LogLevel } from './utils/logger';
-import { getContractsFromConfig } from './utils/checkpoint';
 import { extendSchema } from './utils/graphql';
 import { createKnex } from './knex';
 import { createPgPool } from './pg';
 import { checkpointConfigSchema } from './schemas';
 import { register } from './register';
-import { sleep } from './utils/helpers';
-import { ContractSourceConfig, CheckpointConfig, CheckpointOptions, TemplateSource } from './types';
-import { getTableName } from './utils/database';
+import { CheckpointConfig, CheckpointOptions } from './types';
 import { Container } from './container';
 
 const INDEXER_NAME = 'default';
 
-const BLOCK_PRELOAD_START_RANGE = 1000;
-const BLOCK_RELOAD_MIN_RANGE = 10;
-const BLOCK_PRELOAD_STEP = 100;
-const BLOCK_PRELOAD_TARGET = 10;
-const BLOCK_PRELOAD_OFFSET = 50;
-const DEFAULT_FETCH_INTERVAL = 2000;
-
 export default class Checkpoint {
-  public config: CheckpointConfig;
-  public opts?: CheckpointOptions;
-  public schema: string;
-
   private readonly entityController: GqlEntityController;
   private readonly log: Logger;
-  private readonly indexer: BaseIndexer;
 
   private container: Container;
 
@@ -42,12 +27,6 @@ export default class Checkpoint {
   private knex: Knex;
   private pgPool?: PgPool;
   private checkpointsStore?: CheckpointsStore;
-  private activeTemplates: TemplateSource[] = [];
-  private preloadStep: number = BLOCK_PRELOAD_START_RANGE;
-  private preloadedBlocks: number[] = [];
-  private preloadEndBlock = 0;
-  private cpBlocksCache: number[] | null = [];
-  private blockHashCache: { blockNumber: number; hash: string } | null = null;
 
   constructor(
     config: CheckpointConfig,
@@ -60,11 +39,9 @@ export default class Checkpoint {
       throw new Error(`Checkpoint config is invalid: ${validationResult.error.message}`);
     }
 
-    this.config = config;
-    this.opts = opts;
-    this.schema = extendSchema(schema);
+    const extendedSchema = extendSchema(schema);
 
-    this.entityController = new GqlEntityController(this.schema, config);
+    this.entityController = new GqlEntityController(extendedSchema, config);
 
     this.log = createLogger({
       base: { component: 'checkpoint' },
@@ -88,22 +65,15 @@ export default class Checkpoint {
     this.knex = createKnex(dbConnection);
     this.dbConnection = dbConnection;
 
-    this.indexer = indexer;
-    this.indexer.init({
-      instance: this,
-      log: this.log,
-      abis: opts?.abis
-    });
-
     this.container = new Container(
       INDEXER_NAME,
       this.log,
       this.knex,
       this.store,
-      this.config,
-      this.indexer,
-      this.schema,
-      this.opts
+      config,
+      indexer,
+      extendedSchema,
+      opts
     );
 
     this.container.validateConfig();
@@ -151,16 +121,6 @@ export default class Checkpoint {
     return getGraphQL(schema, this.getBaseContext(), this.entityController.generateSampleQuery());
   }
 
-  public get sourceContracts() {
-    return this.indexer.getProvider().formatAddresses(getContractsFromConfig(this.config));
-  }
-
-  public getCurrentSources(blockNumber: number) {
-    if (!this.config.sources) return [];
-
-    return this.config.sources.filter(source => source.start <= blockNumber);
-  }
-
   /**
    * Starts the indexer.
    *
@@ -171,28 +131,7 @@ export default class Checkpoint {
   public async start() {
     this.log.debug('starting');
 
-    await this.container.validateStore();
-    await this.indexer.getProvider().init();
-
-    const templateSources = await this.store.getTemplateSources(INDEXER_NAME);
-    await Promise.all(
-      templateSources.map(source =>
-        this.executeTemplate(
-          source.template,
-          {
-            contract: source.contractAddress,
-            start: source.startBlock
-          },
-          false
-        )
-      )
-    );
-
-    const blockNum = await this.container.getStartBlockNum();
-    this.preloadEndBlock =
-      (await this.indexer.getProvider().getLatestBlockNumber()) - BLOCK_PRELOAD_OFFSET;
-
-    return await this.next(blockNum);
+    await this.container.start();
   }
 
   /**
@@ -225,47 +164,6 @@ export default class Checkpoint {
     await this.container.resetMetadata();
   }
 
-  private addSource(source: ContractSourceConfig) {
-    if (!this.config.sources) this.config.sources = [];
-
-    this.config.sources.push(source);
-    this.cpBlocksCache = [];
-  }
-
-  public async executeTemplate(
-    name: string,
-    { contract, start }: { contract: string; start: number },
-    persist = true
-  ) {
-    const template = this.config.templates?.[name];
-
-    if (!template) {
-      this.log.warn({ name }, 'template not found');
-      return;
-    }
-
-    const existingTemplate = this.activeTemplates.find(
-      template =>
-        template.template === name &&
-        template.contractAddress === contract &&
-        template.startBlock === start
-    );
-
-    if (existingTemplate) return;
-    this.activeTemplates.push({ template: name, contractAddress: contract, startBlock: start });
-
-    if (persist) {
-      await this.store.insertTemplateSource(INDEXER_NAME, contract, start, name);
-    }
-
-    this.addSource({
-      contract,
-      start,
-      abi: template.abi,
-      events: template.events
-    });
-  }
-
   /**
    * Registers the blocks where a contracts event can be found.
    * This will be used as a skip list for checkpoints while
@@ -279,203 +177,7 @@ export default class Checkpoint {
     checkpointBlocks: { contract: string; blocks: number[] }[]
   ): Promise<void> {
     await this.store.createStore();
-
-    const checkpoints: CheckpointRecord[] = [];
-
-    let finalBlock = 0;
-    checkpointBlocks.forEach(cp => {
-      cp.blocks.forEach(blockNumber => {
-        finalBlock = Math.max(finalBlock, blockNumber);
-        checkpoints.push({
-          blockNumber,
-          contractAddress: cp.contract
-        });
-      });
-    });
-
-    await this.store.insertCheckpoints(INDEXER_NAME, checkpoints);
-  }
-
-  public async setBlockHash(blockNum: number, hash: string) {
-    this.blockHashCache = { blockNumber: blockNum, hash };
-
-    return this.store.setBlockHash(INDEXER_NAME, blockNum, hash);
-  }
-
-  public async setLastIndexedBlock(block: number) {
-    await this.store.setMetadata(INDEXER_NAME, MetadataId.LastIndexedBlock, block);
-  }
-
-  public async insertCheckpoints(checkpoints: CheckpointRecord[]) {
-    await this.store.insertCheckpoints(INDEXER_NAME, checkpoints);
-  }
-
-  public async getWriterParams(): Promise<{
-    instance: Checkpoint;
-  }> {
-    return {
-      instance: this
-    };
-  }
-
-  private async preload(blockNum: number) {
-    if (this.preloadedBlocks.length > 0) return this.preloadedBlocks.shift() as number;
-
-    let currentBlock = blockNum;
-
-    while (currentBlock <= this.preloadEndBlock) {
-      const endBlock = Math.min(currentBlock + this.preloadStep, this.preloadEndBlock);
-      let checkpoints: CheckpointRecord[];
-      try {
-        checkpoints = await this.indexer.getProvider().getCheckpointsRange(currentBlock, endBlock);
-      } catch (e) {
-        this.log.error(
-          { blockNumber: currentBlock, err: e },
-          'error occurred during checkpoint fetching'
-        );
-        await sleep(this.opts?.fetchInterval || DEFAULT_FETCH_INTERVAL);
-        continue;
-      }
-
-      const increase =
-        checkpoints.length > BLOCK_PRELOAD_TARGET ? -BLOCK_PRELOAD_STEP : +BLOCK_PRELOAD_STEP;
-      this.preloadStep = Math.max(BLOCK_RELOAD_MIN_RANGE, this.preloadStep + increase);
-
-      if (checkpoints.length > 0) {
-        this.preloadedBlocks = [...new Set(checkpoints.map(cp => cp.blockNumber).sort())];
-        return this.preloadedBlocks.shift() as number;
-      }
-
-      currentBlock = endBlock + 1;
-    }
-
-    return null;
-  }
-
-  private async next(blockNum: number) {
-    let checkpointBlock, preloadedBlock;
-    if (!this.config.tx_fn && !this.config.global_events) {
-      checkpointBlock = await this.getNextCheckpointBlock(blockNum);
-
-      if (checkpointBlock) {
-        blockNum = checkpointBlock;
-      } else if (blockNum <= this.preloadEndBlock) {
-        preloadedBlock = await this.preload(blockNum);
-        blockNum = preloadedBlock || this.preloadEndBlock + 1;
-      }
-    }
-
-    this.log.debug({ blockNumber: blockNum }, 'next block');
-
-    try {
-      register.setCurrentBlock(BigInt(blockNum));
-
-      const initialSources = this.getCurrentSources(blockNum);
-      const parentHash = await this.getBlockHash(blockNum - 1);
-      const nextBlockNumber = await this.indexer.getProvider().processBlock(blockNum, parentHash);
-      const sources = this.getCurrentSources(nextBlockNumber);
-
-      if (initialSources.length !== sources.length) {
-        this.preloadedBlocks = [];
-      }
-
-      return this.next(nextBlockNumber);
-    } catch (err) {
-      if (err instanceof BlockNotFoundError) {
-        if (this.config.optimistic_indexing) {
-          try {
-            await this.indexer.getProvider().processPool(blockNum);
-          } catch (err) {
-            this.log.error({ blockNumber: blockNum, err }, 'error occurred during pool processing');
-          }
-        }
-      } else if (err instanceof ReorgDetectedError) {
-        const nextBlockNumber = await this.handleReorg(blockNum);
-        return this.next(nextBlockNumber);
-      } else {
-        this.log.error({ blockNumber: blockNum, err }, 'error occurred during block processing');
-      }
-
-      if (checkpointBlock && this.cpBlocksCache) {
-        this.cpBlocksCache.unshift(checkpointBlock);
-      }
-
-      if (preloadedBlock && this.preloadedBlocks) {
-        this.preloadedBlocks.unshift(preloadedBlock);
-      }
-
-      await sleep(this.opts?.fetchInterval || DEFAULT_FETCH_INTERVAL);
-      return this.next(blockNum);
-    }
-  }
-
-  private async handleReorg(blockNumber: number) {
-    this.log.info({ blockNumber }, 'handling reorg');
-
-    let current = blockNumber - 1;
-    let lastGoodBlock: null | number = null;
-    while (lastGoodBlock === null) {
-      const storedBlockHash = await this.store.getBlockHash(INDEXER_NAME, current);
-      const currentBlockHash = await this.indexer.getProvider().getBlockHash(current);
-
-      if (storedBlockHash === null || storedBlockHash === currentBlockHash) {
-        lastGoodBlock = current;
-      } else {
-        current -= 1;
-      }
-    }
-
-    const entities = await this.entityController.schemaObjects;
-    const tables = entities.map(entity => getTableName(entity.name.toLowerCase()));
-
-    await this.knex.transaction(async trx => {
-      for (const tableName of tables) {
-        await trx.table(tableName).whereRaw('lower(block_range) > ?', [lastGoodBlock]).delete();
-
-        await trx
-          .table(tableName)
-          .whereRaw('block_range @> int8(??)', [lastGoodBlock])
-          .update({
-            block_range: this.knex.raw('int8range(lower(block_range), NULL)')
-          });
-      }
-    });
-
-    // TODO: when we have full transaction support, we should include this in the transaction
-    await this.store.removeFutureData(INDEXER_NAME, lastGoodBlock);
-
-    this.cpBlocksCache = null;
-    this.blockHashCache = null;
-
-    this.log.info({ blockNumber: lastGoodBlock }, 'reorg resolved');
-
-    return lastGoodBlock + 1;
-  }
-
-  private async getNextCheckpointBlock(blockNum: number): Promise<number | null> {
-    if (this.cpBlocksCache && this.cpBlocksCache.length !== 0) {
-      return this.cpBlocksCache.shift() || null;
-    }
-
-    const checkpointBlocks = await this.store.getNextCheckpointBlocks(
-      INDEXER_NAME,
-      blockNum,
-      this.sourceContracts,
-      15
-    );
-
-    if (checkpointBlocks.length === 0) return null;
-
-    this.cpBlocksCache = checkpointBlocks;
-    return this.cpBlocksCache.shift() || null;
-  }
-
-  private async getBlockHash(blockNumber: number): Promise<string | null> {
-    if (this.blockHashCache && this.blockHashCache.blockNumber === blockNumber) {
-      return this.blockHashCache.hash;
-    }
-
-    return this.store.getBlockHash(INDEXER_NAME, blockNumber);
+    await this.container.seedCheckpoints(checkpointBlocks);
   }
 
   private get store(): CheckpointsStore {

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,14 +1,24 @@
-import { BaseIndexer } from './providers';
-import { CheckpointConfig, CheckpointOptions } from './types';
-import { CheckpointsStore, MetadataId } from './stores/checkpoints';
+import { BaseIndexer, BlockNotFoundError, Instance, ReorgDetectedError } from './providers';
+import { CheckpointConfig, CheckpointOptions, ContractSourceConfig, TemplateSource } from './types';
+import { CheckpointRecord, CheckpointsStore, MetadataId } from './stores/checkpoints';
 import { Logger } from './utils/logger';
-import { getConfigChecksum } from './utils/checkpoint';
+import { getConfigChecksum, getContractsFromConfig } from './utils/checkpoint';
 import { GqlEntityController } from './graphql/controller';
 import { Knex } from 'knex';
+import { sleep } from './utils/helpers';
+import { register } from './register';
+import { getTableName } from './utils/database';
 
 const SCHEMA_VERSION = 1;
 
-export class Container {
+const BLOCK_PRELOAD_START_RANGE = 1000;
+const BLOCK_RELOAD_MIN_RANGE = 10;
+const BLOCK_PRELOAD_STEP = 100;
+const BLOCK_PRELOAD_TARGET = 10;
+const BLOCK_PRELOAD_OFFSET = 50;
+const DEFAULT_FETCH_INTERVAL = 2000;
+
+export class Container implements Instance {
   private indexerName: string;
 
   public config: CheckpointConfig;
@@ -21,6 +31,14 @@ export class Container {
   private readonly entityController: GqlEntityController;
   private knex: Knex;
 
+  private activeTemplates: TemplateSource[] = [];
+  private cpBlocksCache: number[] | null = [];
+  private blockHashCache: { blockNumber: number; hash: string } | null = null;
+
+  private preloadStep: number = BLOCK_PRELOAD_START_RANGE;
+  private preloadedBlocks: number[] = [];
+  private preloadEndBlock = 0;
+
   constructor(
     indexerName: string,
     log: Logger,
@@ -32,7 +50,7 @@ export class Container {
     opts?: CheckpointOptions
   ) {
     this.indexerName = indexerName;
-    this.log = log;
+    this.log = log.child({ component: 'container', indexer: indexerName });
     this.knex = knex;
     this.store = store;
     this.config = config;
@@ -41,6 +59,275 @@ export class Container {
     this.opts = opts;
 
     this.entityController = new GqlEntityController(this.schema, config);
+
+    this.indexer.init({
+      instance: this,
+      log: this.log,
+      abis: opts?.abis
+    });
+  }
+
+  public get sourceContracts() {
+    return this.indexer.getProvider().formatAddresses(getContractsFromConfig(this.config));
+  }
+
+  public getCurrentSources(blockNumber: number) {
+    if (!this.config.sources) return [];
+
+    return this.config.sources.filter(source => source.start <= blockNumber);
+  }
+
+  private async getNextCheckpointBlock(blockNum: number): Promise<number | null> {
+    if (this.cpBlocksCache && this.cpBlocksCache.length !== 0) {
+      return this.cpBlocksCache.shift() || null;
+    }
+
+    const checkpointBlocks = await this.store.getNextCheckpointBlocks(
+      this.indexerName,
+      blockNum,
+      this.sourceContracts,
+      15
+    );
+
+    if (checkpointBlocks.length === 0) return null;
+
+    this.cpBlocksCache = checkpointBlocks;
+    return this.cpBlocksCache.shift() || null;
+  }
+
+  private async getBlockHash(blockNumber: number): Promise<string | null> {
+    if (this.blockHashCache && this.blockHashCache.blockNumber === blockNumber) {
+      return this.blockHashCache.hash;
+    }
+
+    return this.store.getBlockHash(this.indexerName, blockNumber);
+  }
+
+  private addSource(source: ContractSourceConfig) {
+    if (!this.config.sources) this.config.sources = [];
+
+    this.config.sources.push(source);
+    this.cpBlocksCache = [];
+  }
+
+  public async executeTemplate(
+    name: string,
+    { contract, start }: { contract: string; start: number },
+    persist = true
+  ) {
+    const template = this.config.templates?.[name];
+
+    if (!template) {
+      this.log.warn({ name }, 'template not found');
+      return;
+    }
+
+    const existingTemplate = this.activeTemplates.find(
+      template =>
+        template.template === name &&
+        template.contractAddress === contract &&
+        template.startBlock === start
+    );
+
+    if (existingTemplate) return;
+    this.activeTemplates.push({ template: name, contractAddress: contract, startBlock: start });
+
+    if (persist) {
+      await this.store.insertTemplateSource(this.indexerName, contract, start, name);
+    }
+
+    this.addSource({
+      contract,
+      start,
+      abi: template.abi,
+      events: template.events
+    });
+  }
+
+  getWriterHelpers() {
+    return {
+      executeTemplate: this.executeTemplate.bind(this)
+    };
+  }
+
+  public async setBlockHash(blockNum: number, hash: string) {
+    this.blockHashCache = { blockNumber: blockNum, hash };
+
+    return this.store.setBlockHash(this.indexerName, blockNum, hash);
+  }
+
+  public async setLastIndexedBlock(block: number) {
+    await this.store.setMetadata(this.indexerName, MetadataId.LastIndexedBlock, block);
+  }
+
+  public async insertCheckpoints(checkpoints: CheckpointRecord[]) {
+    await this.store.insertCheckpoints(this.indexerName, checkpoints);
+  }
+
+  /**
+   * Starts the indexer.
+   *
+   * The indexer will invoker the respective writer functions when a contract
+   * event is found.
+   *
+   */
+  public async start() {
+    await this.validateStore();
+    await this.indexer.getProvider().init();
+
+    const templateSources = await this.store.getTemplateSources(this.indexerName);
+    await Promise.all(
+      templateSources.map(source =>
+        this.executeTemplate(
+          source.template,
+          {
+            contract: source.contractAddress,
+            start: source.startBlock
+          },
+          false
+        )
+      )
+    );
+
+    const blockNum = await this.getStartBlockNum();
+    this.preloadEndBlock =
+      (await this.indexer.getProvider().getLatestBlockNumber()) - BLOCK_PRELOAD_OFFSET;
+
+    return await this.next(blockNum);
+  }
+
+  private async preload(blockNum: number) {
+    if (this.preloadedBlocks.length > 0) return this.preloadedBlocks.shift() as number;
+
+    let currentBlock = blockNum;
+
+    while (currentBlock <= this.preloadEndBlock) {
+      const endBlock = Math.min(currentBlock + this.preloadStep, this.preloadEndBlock);
+      let checkpoints: CheckpointRecord[];
+      try {
+        checkpoints = await this.indexer.getProvider().getCheckpointsRange(currentBlock, endBlock);
+      } catch (e) {
+        this.log.error(
+          { blockNumber: currentBlock, err: e },
+          'error occurred during checkpoint fetching'
+        );
+        await sleep(this.opts?.fetchInterval || DEFAULT_FETCH_INTERVAL);
+        continue;
+      }
+
+      const increase =
+        checkpoints.length > BLOCK_PRELOAD_TARGET ? -BLOCK_PRELOAD_STEP : +BLOCK_PRELOAD_STEP;
+      this.preloadStep = Math.max(BLOCK_RELOAD_MIN_RANGE, this.preloadStep + increase);
+
+      if (checkpoints.length > 0) {
+        this.preloadedBlocks = [...new Set(checkpoints.map(cp => cp.blockNumber).sort())];
+        return this.preloadedBlocks.shift() as number;
+      }
+
+      currentBlock = endBlock + 1;
+    }
+
+    return null;
+  }
+
+  private async next(blockNum: number) {
+    let checkpointBlock, preloadedBlock;
+    if (!this.config.tx_fn && !this.config.global_events) {
+      checkpointBlock = await this.getNextCheckpointBlock(blockNum);
+
+      if (checkpointBlock) {
+        blockNum = checkpointBlock;
+      } else if (blockNum <= this.preloadEndBlock) {
+        preloadedBlock = await this.preload(blockNum);
+        blockNum = preloadedBlock || this.preloadEndBlock + 1;
+      }
+    }
+
+    this.log.debug({ blockNumber: blockNum }, 'next block');
+
+    try {
+      register.setCurrentBlock(BigInt(blockNum));
+
+      const initialSources = this.getCurrentSources(blockNum);
+      const parentHash = await this.getBlockHash(blockNum - 1);
+      const nextBlockNumber = await this.indexer.getProvider().processBlock(blockNum, parentHash);
+      const sources = this.getCurrentSources(nextBlockNumber);
+
+      if (initialSources.length !== sources.length) {
+        this.preloadedBlocks = [];
+      }
+
+      return this.next(nextBlockNumber);
+    } catch (err) {
+      if (err instanceof BlockNotFoundError) {
+        if (this.config.optimistic_indexing) {
+          try {
+            await this.indexer.getProvider().processPool(blockNum);
+          } catch (err) {
+            this.log.error({ blockNumber: blockNum, err }, 'error occurred during pool processing');
+          }
+        }
+      } else if (err instanceof ReorgDetectedError) {
+        const nextBlockNumber = await this.handleReorg(blockNum);
+        return this.next(nextBlockNumber);
+      } else {
+        this.log.error({ blockNumber: blockNum, err }, 'error occurred during block processing');
+      }
+
+      if (checkpointBlock && this.cpBlocksCache) {
+        this.cpBlocksCache.unshift(checkpointBlock);
+      }
+
+      if (preloadedBlock && this.preloadedBlocks) {
+        this.preloadedBlocks.unshift(preloadedBlock);
+      }
+
+      await sleep(this.opts?.fetchInterval || DEFAULT_FETCH_INTERVAL);
+      return this.next(blockNum);
+    }
+  }
+
+  private async handleReorg(blockNumber: number) {
+    this.log.info({ blockNumber }, 'handling reorg');
+
+    let current = blockNumber - 1;
+    let lastGoodBlock: null | number = null;
+    while (lastGoodBlock === null) {
+      const storedBlockHash = await this.store.getBlockHash(this.indexerName, current);
+      const currentBlockHash = await this.indexer.getProvider().getBlockHash(current);
+
+      if (storedBlockHash === null || storedBlockHash === currentBlockHash) {
+        lastGoodBlock = current;
+      } else {
+        current -= 1;
+      }
+    }
+
+    const entities = await this.entityController.schemaObjects;
+    const tables = entities.map(entity => getTableName(entity.name.toLowerCase()));
+
+    await this.knex.transaction(async trx => {
+      for (const tableName of tables) {
+        await trx.table(tableName).whereRaw('lower(block_range) > ?', [lastGoodBlock]).delete();
+
+        await trx
+          .table(tableName)
+          .whereRaw('block_range @> int8(??)', [lastGoodBlock])
+          .update({
+            block_range: this.knex.raw('int8range(lower(block_range), NULL)')
+          });
+      }
+    });
+
+    // TODO: when we have full transaction support, we should include this in the transaction
+    await this.store.removeFutureData(this.indexerName, lastGoodBlock);
+
+    this.cpBlocksCache = null;
+    this.blockHashCache = null;
+
+    this.log.info({ blockNumber: lastGoodBlock }, 'reorg resolved');
+
+    return lastGoodBlock + 1;
   }
 
   /**
@@ -75,6 +362,34 @@ export class Container {
   public async resetMetadata() {
     await this.store.resetStore();
     await this.store.setMetadata(this.indexerName, MetadataId.SchemaVersion, SCHEMA_VERSION);
+  }
+
+  /**
+   * Registers the blocks where a contracts event can be found.
+   * This will be used as a skip list for checkpoints while
+   * indexing relevant blocks. Using this seed function can significantly
+   * reduce the time for Checkpoint to re-index blocks.
+   *
+   * This should be called before the start() method is called.
+   *
+   */
+  public async seedCheckpoints(
+    checkpointBlocks: { contract: string; blocks: number[] }[]
+  ): Promise<void> {
+    const checkpoints: CheckpointRecord[] = [];
+
+    let finalBlock = 0;
+    checkpointBlocks.forEach(cp => {
+      cp.blocks.forEach(blockNumber => {
+        finalBlock = Math.max(finalBlock, blockNumber);
+        checkpoints.push({
+          blockNumber,
+          contractAddress: cp.contract
+        });
+      });
+    });
+
+    await this.store.insertCheckpoints(this.indexerName, checkpoints);
   }
 
   public getConfigStartBlock() {

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,4 +1,3 @@
-import Checkpoint from '../checkpoint';
 import { CheckpointRecord } from '../stores/checkpoints';
 import { Logger } from '../utils/logger';
 import { CheckpointConfig, ContractSourceConfig } from '../types';
@@ -9,9 +8,13 @@ export type Instance = {
   setBlockHash(blockNum: number, hash: string);
   setLastIndexedBlock(blockNum: number);
   insertCheckpoints(checkpoints: CheckpointRecord[]);
-  getWriterParams(): Promise<{
-    instance: Checkpoint;
-  }>;
+  getWriterHelpers(): {
+    executeTemplate(
+      template: string,
+      config: { contract: string; start: number },
+      persist?: boolean
+    );
+  };
 };
 
 export class BlockNotFoundError extends Error {

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -110,14 +110,14 @@ export class EvmProvider extends BaseProvider {
   ) {
     this.log.debug({ txIndex }, 'handling transaction');
 
-    const writerParams = await this.instance.getWriterParams();
+    const helpers = await this.instance.getWriterHelpers();
 
     if (this.instance.config.tx_fn) {
       await this.writers[this.instance.config.tx_fn]({
         blockNumber,
         block,
         tx,
-        ...writerParams
+        helpers
       });
     }
 
@@ -145,7 +145,7 @@ export class EvmProvider extends BaseProvider {
           tx,
           rawEvent: event,
           eventIndex,
-          ...writerParams
+          helpers
         });
       }
     }
@@ -189,7 +189,7 @@ export class EvmProvider extends BaseProvider {
                 rawEvent: log,
                 event: parsedEvent,
                 eventIndex,
-                ...writerParams
+                helpers
               });
             }
           }

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -186,14 +186,14 @@ export class StarknetProvider extends BaseProvider {
     }
 
     let wasTransactionProcessed = false;
-    const writerParams = await this.instance.getWriterParams();
+    const helpers = await this.instance.getWriterHelpers();
 
     if (this.instance.config.tx_fn) {
       await this.writers[this.instance.config.tx_fn]({
         blockNumber,
         block,
         tx,
-        ...writerParams
+        helpers
       });
 
       wasTransactionProcessed = true;
@@ -223,7 +223,7 @@ export class StarknetProvider extends BaseProvider {
           tx,
           rawEvent: event,
           eventIndex,
-          ...writerParams
+          helpers
         });
 
         wasTransactionProcessed = true;
@@ -253,7 +253,7 @@ export class StarknetProvider extends BaseProvider {
           block,
           blockNumber,
           tx,
-          ...writerParams
+          helpers
         });
 
         wasTransactionProcessed = true;
@@ -289,7 +289,7 @@ export class StarknetProvider extends BaseProvider {
                 rawEvent: event,
                 event: parsedEvent,
                 eventIndex,
-                ...writerParams
+                helpers
               });
 
               wasTransactionProcessed = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import Checkpoint from './checkpoint';
 import { LogLevel } from './utils/logger';
 import {
   contractSourceConfigSchema,
   contractTemplateSchema,
   checkpointConfigSchema
 } from './schemas';
+import { Instance } from './providers';
 
 export type TemplateSource = {
   contractAddress: string;
@@ -40,5 +40,5 @@ export type BaseWriterParams = {
   blockNumber: number;
   eventIndex?: number;
   source?: ContractSourceConfig;
-  instance: Checkpoint;
+  helpers: ReturnType<Instance['getWriterHelpers']>;
 };


### PR DESCRIPTION
This PR moves lifecycle to container class. This change is internal only, no external API change happened.
This encapsulates indexer and separates it from main Checkpoint instance.

## Test plan
1. Use checkpoint-template.
2. Make sure `resetMetadata` is called before `reset`.
4. It indexes data as before.