### PR TITLE
feat: add support for multi chain indexing

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -14,14 +14,14 @@ import {
 import pluralize from 'pluralize';
 import { GqlEntityController } from './graphql/controller';
 import { extendSchema, getDerivedFromDirective } from './utils/graphql';
-import { CheckpointConfig } from './types';
+import { OverridesConfig } from './types';
 
 type TypeInfo = {
   type: string;
   initialValue: any;
 };
 
-type DecimalTypes = NonNullable<CheckpointConfig['decimal_types']>;
+type DecimalTypes = NonNullable<OverridesConfig['decimal_types']>;
 
 const DEFAULT_DECIMAL_TYPES = {
   Decimal: {
@@ -114,7 +114,7 @@ export const getJSType = (
 
 export const codegen = (
   schema: string,
-  config: CheckpointConfig,
+  config: OverridesConfig,
   format: 'typescript' | 'javascript'
 ) => {
   const decimalTypes = config.decimal_types || DEFAULT_DECIMAL_TYPES;
@@ -146,9 +146,9 @@ export const codegen = (
 
     contents +=
       format === 'javascript'
-        ? `  constructor(id) {\n`
-        : `  constructor(id: ${idType.baseType}) {\n`;
-    contents += `    super(${modelName}.tableName);\n\n`;
+        ? `  constructor(id, indexerName) {\n`
+        : `  constructor(id: ${idType.baseType}, indexerName: string) {\n`;
+    contents += `    super(${modelName}.tableName, indexerName);\n\n`;
     typeFields.forEach(field => {
       const fieldType = field.type instanceof GraphQLNonNull ? field.type.ofType : field.type;
       if (
@@ -167,11 +167,11 @@ export const codegen = (
 
     contents +=
       format === 'javascript'
-        ? `  static async loadEntity(id) {\n`
-        : `  static async loadEntity(id: ${idType.baseType}): Promise<${modelName} | null> {\n`;
-    contents += `    const entity = await super._loadEntity(${modelName}.tableName, id);\n`;
+        ? `  static async loadEntity(id, indexerName) {\n`
+        : `  static async loadEntity(id: ${idType.baseType}, indexerName: string): Promise<${modelName} | null> {\n`;
+    contents += `    const entity = await super._loadEntity(${modelName}.tableName, id, indexerName);\n`;
     contents += `    if (!entity) return null;\n\n`;
-    contents += `    const model = new ${modelName}(id);\n`;
+    contents += `    const model = new ${modelName}(id, indexerName);\n`;
     contents += `    model.setExists();\n\n`;
     contents += `    for (const key in entity) {\n`;
     contents += `      const value = entity[key] !== null && typeof entity[key] === 'object'\n`;

--- a/src/container.ts
+++ b/src/container.ts
@@ -246,7 +246,7 @@ export class Container implements Instance {
     this.log.debug({ blockNumber: blockNum }, 'next block');
 
     try {
-      register.setCurrentBlock(BigInt(blockNum));
+      register.setCurrentBlock(this.indexerName, BigInt(blockNum));
 
       const initialSources = this.getCurrentSources(blockNum);
       const parentHash = await this.getBlockHash(blockNum - 1);

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -250,7 +250,7 @@ export class GqlEntityController {
         builder = builder.raw(
           knex
             .raw(
-              'ALTER TABLE ?? ADD EXCLUDE USING GIST (id WITH =, indexer WITH =, block_range WITH &&)',
+              'ALTER TABLE ?? ADD EXCLUDE USING GIST (id WITH =, _indexer WITH =, block_range WITH &&)',
               [tableName]
             )
             .toQuery()

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'graphql';
 import DataLoader from 'dataloader';
 import { ResolverContextInput } from './resolvers';
-import { getTableName, applyBlockFilter } from '../utils/database';
+import { getTableName, applyQueryFilter, QueryFilter } from '../utils/database';
 
 /**
  * Creates getLoader function that will return existing, or create a new dataloader
@@ -20,7 +20,7 @@ import { getTableName, applyBlockFilter } from '../utils/database';
 export const createGetLoader = (context: ResolverContextInput) => {
   const loaders = {};
 
-  return (name: string, field = 'id', block?: number) => {
+  return (name: string, field = 'id', filter: QueryFilter) => {
     const key = `${name}-${field}`;
 
     if (!loaders[key]) {
@@ -31,7 +31,7 @@ export const createGetLoader = (context: ResolverContextInput) => {
           .select('*')
           .from(tableName)
           .whereIn(field, ids as string[]);
-        query = applyBlockFilter(query, tableName, block);
+        query = applyQueryFilter(query, tableName, filter);
 
         context.log.debug({ sql: query.toQuery(), ids }, 'executing batched query');
 

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -83,6 +83,7 @@ export const MetadataGraphQLObject = new GraphQLObjectType({
   description: 'Core metadata values used internally by Checkpoint',
   fields: {
     id: { type: new GraphQLNonNull(GraphQLID), description: 'example: last_indexed_block' },
+    indexer: { type: new GraphQLNonNull(GraphQLString) },
     value: { type: GraphQLString }
   }
 });
@@ -100,6 +101,7 @@ export const CheckpointsGraphQLObject = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLID),
       description: 'id computed as last 5 bytes of sha256(contract+block)'
     },
+    indexer: { type: new GraphQLNonNull(GraphQLString) },
     block_number: {
       type: new GraphQLNonNull(GraphQLInt)
     },

--- a/src/orm/model.ts
+++ b/src/orm/model.ts
@@ -14,7 +14,7 @@ export default class Model {
 
   private async _update() {
     const knex = register.getKnex();
-    const currentBlock = register.getCurrentBlock();
+    const currentBlock = register.getCurrentBlock(this.indexerName);
 
     const diff = Object.fromEntries(
       [...this.values.entries()].filter(([key]) => this.valuesImplicitlySet.has(key))
@@ -45,7 +45,7 @@ export default class Model {
   }
 
   private async _insert() {
-    const currentBlock = register.getCurrentBlock();
+    const currentBlock = register.getCurrentBlock(this.indexerName);
 
     const entity = Object.fromEntries(this.values.entries());
 
@@ -60,7 +60,7 @@ export default class Model {
   }
 
   private async _delete() {
-    const currentBlock = register.getCurrentBlock();
+    const currentBlock = register.getCurrentBlock(this.indexerName);
 
     return register
       .getKnex()

--- a/src/orm/model.ts
+++ b/src/orm/model.ts
@@ -2,12 +2,14 @@ import { register } from '../register';
 
 export default class Model {
   private tableName: string;
+  private indexerName: string;
   private values = new Map<string, any>();
   private valuesImplicitlySet = new Set<string>();
   private exists = false;
 
-  constructor(tableName: string) {
+  constructor(tableName: string, indexerName: string) {
     this.tableName = tableName;
+    this.indexerName = indexerName;
   }
 
   private async _update() {
@@ -22,6 +24,7 @@ export default class Model {
       await trx
         .table(this.tableName)
         .where('id', this.get('id'))
+        .andWhere('indexer', this.indexerName)
         .andWhereRaw('upper_inf(block_range)')
         .update({
           block_range: knex.raw('int8range(lower(block_range), ?)', [currentBlock])
@@ -51,6 +54,7 @@ export default class Model {
       .table(this.tableName)
       .insert({
         ...entity,
+        indexer: this.indexerName,
         block_range: register.getKnex().raw('int8range(?, NULL)', [currentBlock])
       });
   }
@@ -62,6 +66,7 @@ export default class Model {
       .getKnex()
       .table(this.tableName)
       .where('id', this.get('id'))
+      .andWhere('indexer', this.indexerName)
       .update({
         block_range: register.getKnex().raw('int8range(lower(block_range), ?)', [currentBlock])
       });
@@ -86,7 +91,8 @@ export default class Model {
 
   static async _loadEntity(
     tableName: string,
-    id: string | number
+    id: string | number,
+    indexerName: string
   ): Promise<Record<string, any> | null> {
     const knex = register.getKnex();
 
@@ -94,6 +100,7 @@ export default class Model {
       .table(tableName)
       .select('*')
       .where('id', id)
+      .andWhere('indexer', indexerName)
       .andWhereRaw('upper_inf(block_range)')
       .first();
     if (!entity) return null;

--- a/src/orm/model.ts
+++ b/src/orm/model.ts
@@ -24,7 +24,7 @@ export default class Model {
       await trx
         .table(this.tableName)
         .where('id', this.get('id'))
-        .andWhere('indexer', this.indexerName)
+        .andWhere('_indexer', this.indexerName)
         .andWhereRaw('upper_inf(block_range)')
         .update({
           block_range: knex.raw('int8range(lower(block_range), ?)', [currentBlock])
@@ -54,7 +54,7 @@ export default class Model {
       .table(this.tableName)
       .insert({
         ...entity,
-        indexer: this.indexerName,
+        _indexer: this.indexerName,
         block_range: register.getKnex().raw('int8range(?, NULL)', [currentBlock])
       });
   }
@@ -66,7 +66,7 @@ export default class Model {
       .getKnex()
       .table(this.tableName)
       .where('id', this.get('id'))
-      .andWhere('indexer', this.indexerName)
+      .andWhere('_indexer', this.indexerName)
       .update({
         block_range: register.getKnex().raw('int8range(lower(block_range), ?)', [currentBlock])
       });
@@ -100,7 +100,7 @@ export default class Model {
       .table(tableName)
       .select('*')
       .where('id', id)
-      .andWhere('indexer', indexerName)
+      .andWhere('_indexer', indexerName)
       .andWhereRaw('upper_inf(block_range)')
       .first();
     if (!entity) return null;

--- a/src/register.ts
+++ b/src/register.ts
@@ -2,14 +2,14 @@ import { Knex } from 'knex';
 
 function createRegister() {
   let knexInstance: Knex | null = null;
-  let currentBlock = 0n;
+  const currentBlocks = new Map<string, bigint>();
 
   return {
-    getCurrentBlock() {
-      return currentBlock;
+    getCurrentBlock(indexerName: string) {
+      return currentBlocks.get(indexerName) || 0n;
     },
-    setCurrentBlock(block: bigint) {
-      currentBlock = block;
+    setCurrentBlock(indexerName: string, block: bigint) {
+      currentBlocks.set(indexerName, block);
     },
     getKnex() {
       if (!knexInstance) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,6 +21,16 @@ export const contractTemplateSchema = z.object({
 export const checkpointConfigSchema = z.object({
   network_node_url: z.string().url(),
   optimistic_indexing: z.boolean().optional(),
+  fetch_interval: z.number().optional(),
+  start: z.number().gte(0).optional(),
+  tx_fn: z.string().optional(),
+  global_events: z.array(contractEventConfigSchema).optional(),
+  sources: z.array(contractSourceConfigSchema).optional(),
+  templates: z.record(contractTemplateSchema).optional(),
+  abis: z.record(z.any()).optional()
+});
+
+export const overridesConfigSchema = z.object({
   decimal_types: z
     .record(
       z.object({
@@ -28,10 +38,5 @@ export const checkpointConfigSchema = z.object({
         d: z.number()
       })
     )
-    .optional(),
-  start: z.number().gte(0).optional(),
-  tx_fn: z.string().optional(),
-  global_events: z.array(contractEventConfigSchema).optional(),
-  sources: z.array(contractSourceConfigSchema).optional(),
-  templates: z.record(contractTemplateSchema).optional()
+    .optional()
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,8 @@ import { LogLevel } from './utils/logger';
 import {
   contractSourceConfigSchema,
   contractTemplateSchema,
-  checkpointConfigSchema
+  checkpointConfigSchema,
+  overridesConfigSchema
 } from './schemas';
 import { Instance } from './providers';
 
@@ -22,19 +23,17 @@ export interface CheckpointOptions {
   // optionally format logs to pretty output.
   // Not recommended for production.
   prettifyLogs?: boolean;
-  // Optional interval in milliseconds to check for new blocks.
-  fetchInterval?: number;
   // Optional database connection string. For now only accepts PostgreSQL and MySQL/MariaDB
   // connection string. If no provided will default to looking up a value in
   // the DATABASE_URL environment.
   dbConnection?: string;
-  // Abis for contracts needed for automatic event parsing
-  abis?: Record<string, any>;
+  overridesConfig?: OverridesConfig;
 }
 
 export type ContractSourceConfig = z.infer<typeof contractSourceConfigSchema>;
 export type ContractTemplate = z.infer<typeof contractTemplateSchema>;
 export type CheckpointConfig = z.infer<typeof checkpointConfigSchema>;
+export type OverridesConfig = z.infer<typeof overridesConfigSchema>;
 
 export type BaseWriterParams = {
   blockNumber: number;

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -26,9 +26,11 @@ export function applyQueryFilter(
   tableName: string,
   filters: QueryFilter
 ) {
+  const isInternalTable = INTERNAL_TABLES.includes(tableName);
+
   let filteredQuery = query;
 
-  if (!INTERNAL_TABLES.includes(tableName)) {
+  if (!isInternalTable) {
     filteredQuery =
       filters.block !== undefined
         ? query.andWhereRaw(`${tableName}.block_range @> int8(??)`, [filters.block])
@@ -36,7 +38,9 @@ export function applyQueryFilter(
   }
 
   if (filters.indexer !== undefined) {
-    filteredQuery = query.andWhere(`${tableName}.indexer`, filters.indexer);
+    const columnName = isInternalTable ? 'indexer' : `_indexer`;
+
+    filteredQuery = query.andWhere(`${tableName}.${columnName}`, filters.indexer);
   }
 
   return filteredQuery;

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -13,14 +13,6 @@ export const getTableName = (name: string) => {
   return pluralize(name);
 };
 
-export function applyBlockFilter(query: Knex.QueryBuilder, tableName: string, block?: number) {
-  if (INTERNAL_TABLES.includes(tableName)) return query;
-
-  return block !== undefined
-    ? query.andWhereRaw(`${tableName}.block_range @> int8(??)`, [block])
-    : query.andWhereRaw(`upper_inf(${tableName}.block_range)`);
-}
-
 export function applyQueryFilter(
   query: Knex.QueryBuilder,
   tableName: string,

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -41,7 +41,7 @@ export const extendSchema = (schema: string): string => {
     ObjectTypeDefinition(node) {
       const indexerField = {
         kind: 'FieldDefinition',
-        name: { kind: 'Name', value: 'indexer' },
+        name: { kind: 'Name', value: '_indexer' },
         type: {
           kind: 'NonNullType',
           type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } }

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -6,8 +6,8 @@ exports[`codegen should generate javascript code 1`] = `
 export class Space extends Model {
   static tableName = 'spaces';
 
-  constructor(id) {
-    super(Space.tableName);
+  constructor(id, indexerName) {
+    super(Space.tableName, indexerName);
 
     this.initialSet('id', id);
     this.initialSet('name', null);
@@ -18,13 +18,14 @@ export class Space extends Model {
     this.initialSet('quorum', 0);
     this.initialSet('strategies', "[]");
     this.initialSet('strategies_nonnull', "[]");
+    this.initialSet('indexer', "");
   }
 
-  static async loadEntity(id) {
-    const entity = await super._loadEntity(Space.tableName, id);
+  static async loadEntity(id, indexerName) {
+    const entity = await super._loadEntity(Space.tableName, id, indexerName);
     if (!entity) return null;
 
-    const model = new Space(id);
+    const model = new Space(id, indexerName);
     model.setExists();
 
     for (const key in entity) {
@@ -108,13 +109,21 @@ export class Space extends Model {
   set strategies_nonnull(value) {
     this.set('strategies_nonnull', JSON.stringify(value));
   }
+
+  get indexer() {
+    return this.get('indexer');
+  }
+
+  set indexer(value) {
+    this.set('indexer', value);
+  }
 }
 
 export class Proposal extends Model {
   static tableName = 'proposals';
 
-  constructor(id) {
-    super(Proposal.tableName);
+  constructor(id, indexerName) {
+    super(Proposal.tableName, indexerName);
 
     this.initialSet('id', id);
     this.initialSet('proposal_id', 0);
@@ -123,13 +132,14 @@ export class Proposal extends Model {
     this.initialSet('scores_total', 0);
     this.initialSet('active', false);
     this.initialSet('progress', "0");
+    this.initialSet('indexer', "");
   }
 
-  static async loadEntity(id) {
-    const entity = await super._loadEntity(Proposal.tableName, id);
+  static async loadEntity(id, indexerName) {
+    const entity = await super._loadEntity(Proposal.tableName, id, indexerName);
     if (!entity) return null;
 
-    const model = new Proposal(id);
+    const model = new Proposal(id, indexerName);
     model.setExists();
 
     for (const key in entity) {
@@ -197,6 +207,14 @@ export class Proposal extends Model {
   set progress(value) {
     this.set('progress', value);
   }
+
+  get indexer() {
+    return this.get('indexer');
+  }
+
+  set indexer(value) {
+    this.set('indexer', value);
+  }
 }
 "
 `;
@@ -207,8 +225,8 @@ exports[`codegen should generate typescript code 1`] = `
 export class Space extends Model {
   static tableName = 'spaces';
 
-  constructor(id: string) {
-    super(Space.tableName);
+  constructor(id: string, indexerName: string) {
+    super(Space.tableName, indexerName);
 
     this.initialSet('id', id);
     this.initialSet('name', null);
@@ -219,13 +237,14 @@ export class Space extends Model {
     this.initialSet('quorum', 0);
     this.initialSet('strategies', "[]");
     this.initialSet('strategies_nonnull', "[]");
+    this.initialSet('indexer', "");
   }
 
-  static async loadEntity(id: string): Promise<Space | null> {
-    const entity = await super._loadEntity(Space.tableName, id);
+  static async loadEntity(id: string, indexerName: string): Promise<Space | null> {
+    const entity = await super._loadEntity(Space.tableName, id, indexerName);
     if (!entity) return null;
 
-    const model = new Space(id);
+    const model = new Space(id, indexerName);
     model.setExists();
 
     for (const key in entity) {
@@ -309,13 +328,21 @@ export class Space extends Model {
   set strategies_nonnull(value: string[]) {
     this.set('strategies_nonnull', JSON.stringify(value));
   }
+
+  get indexer(): string {
+    return this.get('indexer');
+  }
+
+  set indexer(value: string) {
+    this.set('indexer', value);
+  }
 }
 
 export class Proposal extends Model {
   static tableName = 'proposals';
 
-  constructor(id: string) {
-    super(Proposal.tableName);
+  constructor(id: string, indexerName: string) {
+    super(Proposal.tableName, indexerName);
 
     this.initialSet('id', id);
     this.initialSet('proposal_id', 0);
@@ -324,13 +351,14 @@ export class Proposal extends Model {
     this.initialSet('scores_total', 0);
     this.initialSet('active', false);
     this.initialSet('progress', "0");
+    this.initialSet('indexer', "");
   }
 
-  static async loadEntity(id: string): Promise<Proposal | null> {
-    const entity = await super._loadEntity(Proposal.tableName, id);
+  static async loadEntity(id: string, indexerName: string): Promise<Proposal | null> {
+    const entity = await super._loadEntity(Proposal.tableName, id, indexerName);
     if (!entity) return null;
 
-    const model = new Proposal(id);
+    const model = new Proposal(id, indexerName);
     model.setExists();
 
     for (const key in entity) {
@@ -397,6 +425,14 @@ export class Proposal extends Model {
 
   set progress(value: string) {
     this.set('progress', value);
+  }
+
+  get indexer(): string {
+    return this.get('indexer');
+  }
+
+  set indexer(value: string) {
+    this.set('indexer', value);
   }
 }
 "

--- a/test/unit/__snapshots__/codegen.test.ts.snap
+++ b/test/unit/__snapshots__/codegen.test.ts.snap
@@ -18,7 +18,7 @@ export class Space extends Model {
     this.initialSet('quorum', 0);
     this.initialSet('strategies', "[]");
     this.initialSet('strategies_nonnull', "[]");
-    this.initialSet('indexer', "");
+    this.initialSet('_indexer', "");
   }
 
   static async loadEntity(id, indexerName) {
@@ -110,12 +110,12 @@ export class Space extends Model {
     this.set('strategies_nonnull', JSON.stringify(value));
   }
 
-  get indexer() {
-    return this.get('indexer');
+  get _indexer() {
+    return this.get('_indexer');
   }
 
-  set indexer(value) {
-    this.set('indexer', value);
+  set _indexer(value) {
+    this.set('_indexer', value);
   }
 }
 
@@ -132,7 +132,7 @@ export class Proposal extends Model {
     this.initialSet('scores_total', 0);
     this.initialSet('active', false);
     this.initialSet('progress', "0");
-    this.initialSet('indexer', "");
+    this.initialSet('_indexer', "");
   }
 
   static async loadEntity(id, indexerName) {
@@ -208,12 +208,12 @@ export class Proposal extends Model {
     this.set('progress', value);
   }
 
-  get indexer() {
-    return this.get('indexer');
+  get _indexer() {
+    return this.get('_indexer');
   }
 
-  set indexer(value) {
-    this.set('indexer', value);
+  set _indexer(value) {
+    this.set('_indexer', value);
   }
 }
 "
@@ -237,7 +237,7 @@ export class Space extends Model {
     this.initialSet('quorum', 0);
     this.initialSet('strategies', "[]");
     this.initialSet('strategies_nonnull', "[]");
-    this.initialSet('indexer', "");
+    this.initialSet('_indexer', "");
   }
 
   static async loadEntity(id: string, indexerName: string): Promise<Space | null> {
@@ -329,12 +329,12 @@ export class Space extends Model {
     this.set('strategies_nonnull', JSON.stringify(value));
   }
 
-  get indexer(): string {
-    return this.get('indexer');
+  get _indexer(): string {
+    return this.get('_indexer');
   }
 
-  set indexer(value: string) {
-    this.set('indexer', value);
+  set _indexer(value: string) {
+    this.set('_indexer', value);
   }
 }
 
@@ -351,7 +351,7 @@ export class Proposal extends Model {
     this.initialSet('scores_total', 0);
     this.initialSet('active', false);
     this.initialSet('progress', "0");
-    this.initialSet('indexer', "");
+    this.initialSet('_indexer', "");
   }
 
   static async loadEntity(id: string, indexerName: string): Promise<Proposal | null> {
@@ -427,12 +427,12 @@ export class Proposal extends Model {
     this.set('progress', value);
   }
 
-  get indexer(): string {
-    return this.get('indexer');
+  get _indexer(): string {
+    return this.get('_indexer');
   }
 
-  set indexer(value: string) {
-    this.set('indexer', value);
+  set _indexer(value: string) {
+    this.set('_indexer', value);
   }
 }
 "

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -171,16 +171,13 @@ describe('getJSType', () => {
 });
 
 describe('codegen', () => {
-  const config = {
-    network_node_url: '',
-    sources: []
-  };
+  const overridesConfig = {};
 
   it('should generate typescript code', () => {
-    expect(codegen(SCHEMA_SOURCE, config, 'typescript')).toMatchSnapshot();
+    expect(codegen(SCHEMA_SOURCE, overridesConfig, 'typescript')).toMatchSnapshot();
   });
 
   it('should generate javascript code', () => {
-    expect(codegen(SCHEMA_SOURCE, config, 'javascript')).toMatchSnapshot();
+    expect(codegen(SCHEMA_SOURCE, overridesConfig, 'javascript')).toMatchSnapshot();
   });
 });

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -19,8 +19,8 @@ create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
 
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
-  vote(id: Int!, block: Int): Vote
-  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, block: Int, where: Vote_filter): [Vote]
+  vote(id: Int!, indexer: String, block: Int): Vote
+  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote]
 }
 
 type Vote {

--- a/test/unit/utils/database.test.ts
+++ b/test/unit/utils/database.test.ts
@@ -1,5 +1,5 @@
 import knex from 'knex';
-import { getTableName, applyBlockFilter } from '../../../src/utils/database';
+import { getTableName, applyQueryFilter } from '../../../src/utils/database';
 
 const mockKnex = knex({
   client: 'sqlite3',
@@ -30,27 +30,41 @@ describe('getTableName', () => {
   });
 });
 
-describe('applyBlockFilter', () => {
-  it('should not apply filter for internal tables', () => {
+describe('applyQueryFilter', () => {
+  it('should not apply block filter filter for internal tables', () => {
     const query = mockKnex.select('*').from('_metadatas');
 
-    const result = applyBlockFilter(query, '_metadatas', 123);
+    const result = applyQueryFilter(query, '_metadatas', { block: 123, indexer: 'indexer' });
 
-    expect(result.toString()).toBe('select * from `_metadatas`');
+    expect(result.toString()).toBe(
+      "select * from `_metadatas` where `_metadatas`.`indexer` = 'indexer'"
+    );
   });
 
   it('should apply capped block filter if block is provided', () => {
     const query = mockKnex.select('*').from('posts');
 
-    const result = applyBlockFilter(query, 'posts', 123);
+    const result = applyQueryFilter(query, 'posts', { block: 123, indexer: 'indexer' });
 
-    expect(result.toString()).toBe('select * from `posts` where posts.block_range @> int8(123)');
+    expect(result.toString()).toBe(
+      "select * from `posts` where posts.block_range @> int8(123) and `posts`.`_indexer` = 'indexer'"
+    );
   });
 
   it('should apply upper_inf block filter if block is not provided', () => {
     const query = mockKnex.select('*').from('posts');
 
-    const result = applyBlockFilter(query, 'posts');
+    const result = applyQueryFilter(query, 'posts', { indexer: 'indexer' });
+
+    expect(result.toString()).toBe(
+      "select * from `posts` where upper_inf(posts.block_range) and `posts`.`_indexer` = 'indexer'"
+    );
+  });
+
+  it('should not apply indexer filter if not provided', () => {
+    const query = mockKnex.select('*').from('posts');
+
+    const result = applyQueryFilter(query, 'posts', {});
 
     expect(result.toString()).toBe('select * from `posts` where upper_inf(posts.block_range)');
   });


### PR DESCRIPTION
## Summary

Few forced changes for consumers:
- ORM now requires indexer to be specified to know which indexer entity belongs to.
- Things had to move around `CheckpointConfig`, `CheckpointsOptions` and `OverridesConfig` (new, used for database options, like decimals as it needs static config for ORM).

```ts
const mainnetConfig = createConfig('mainnet');
const sepoliaConfig = createConfig('sepolia');

const mainnetIndexer = new starknet.StarknetIndexer(createStarknetWriters('mainnet'));
const sepoliaIndexer = new starknet.StarknetIndexer(createStarknetWriters('sepolia'));

const checkpoint = new Checkpoint(schema, {
  logLevel: LogLevel.Info,
  prettifyLogs: true
});

checkpoint.addIndexer('mainnet', mainnetConfig, mainnetIndexer);
checkpoint.addIndexer('sepolia', sepoliaConfig, sepoliaIndexer);
```

## Test plan 

- Test against updated [checkpoint-template](https://github.com/checkpoint-labs/checkpoint-template/pull/10)
- Test against updated [sx-api](https://github.com/snapshot-labs/sx-monorepo/pull/1092)