### PR TITLE
chore: pin starknet

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pino": "^8.3.1",
     "pino-pretty": "^8.1.0",
     "pluralize": "^8.0.0",
-    "starknet": "^5.19.3",
+    "starknet": "~5.19.3",
     "yargs": "^17.7.2",
     "zod": "^3.21.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,9 +1093,9 @@
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
 "@noble/hashes@~1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
-  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
+  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4373,7 +4373,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet@^5.19.3:
+starknet@~5.19.3:
   version "5.19.3"
   resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.19.3.tgz#fa43ed55b1b33718b900eaf67b1ae90e32226303"
   integrity sha512-lftyE2mTnkguma3dTnIW2miTjLX25Snu7pBWpOB2LjFr9ja1nfXPITOjAkDHeOFwv1jRXLlGCAxxGbl3lxgbFQ==


### PR DESCRIPTION
Within 5 version starknet makes some changes to exposed types which we depend on. We have to pin it to specific version for now to avoid issues with consumers having unsupported version.