### PR TITLE
chore: replace simple comments with jsdoc

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -31,6 +31,7 @@ export const checkpointConfigSchema = z.object({
 });
 
 export const overridesConfigSchema = z.object({
+  /** Decimal types to define for use in your schema. */
   decimal_types: z
     .record(
       z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,18 +15,21 @@ export type TemplateSource = {
 };
 
 export interface CheckpointOptions {
-  // Setting to true will trigger reset of database on config changes.
+  /** Setting this to true will trigger reset of database on config changes. */
   resetOnConfigChange?: boolean;
-  // Set the log output levels for checkpoint. Defaults to Error.
-  // Note, this does not affect the log outputs in writers.
+  /**
+   * Set the log output levels for checkpoint. Defaults to Error.
+   * Note, this does not affect the log outputs in writers.
+   */
   logLevel?: LogLevel;
-  // optionally format logs to pretty output.
-  // Not recommended for production.
+  /** Format logs to pretty output. Not recommended for production. */
   prettifyLogs?: boolean;
-  // Optional database connection string. For now only accepts PostgreSQL and MySQL/MariaDB
-  // connection string. If no provided will default to looking up a value in
-  // the DATABASE_URL environment.
+  /**
+   * Optional database connection string. Must be PostgreSQL connection string.
+   * If not provided connection strinng will be read from DATABASE_URL environment variable.
+   */
   dbConnection?: string;
+  /** Overrides for database types. */
   overridesConfig?: OverridesConfig;
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,19 +1,18 @@
 import pino, { Logger as PinoLogger, LoggerOptions } from 'pino';
 
-// LogLevel to control what levels of logs are
-// required.
+/** The minimum level to log. */
 export enum LogLevel {
-  // silent to disable all logging
+  /** Disable all logs.  */
   Silent = 'silent',
-  // fatal to log unrecoverable errors
+  /** Log unrecoverable errors. */
   Fatal = 'fatal',
-  // error to log general errors
+  /** Log general errors. */
   Error = 'error',
-  // warn to log alerts or notices
+  /** Log alerts or notices */
   Warn = 'warn',
-  // info to log useful information
+  /** Log useful information. */
   Info = 'info',
-  // debug to log debug and trace information
+  /** Log debug and trace information. */
   Debug = 'debug'
 }
 


### PR DESCRIPTION
This way we get annotations for (some of) our types:

<img width="863" alt="image" src="https://github.com/user-attachments/assets/3d13efdc-53fa-41d8-b694-1831aa12a328" />

<img width="713" alt="image" src="https://github.com/user-attachments/assets/b2e8803d-529e-4f50-9471-ac0b4d05c11a" />
