### PR TITLE
feat: add schema generation as codegen step

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,8 +1,6 @@
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
-import { addResolversToSchema } from '@graphql-tools/schema';
 import { Knex } from 'knex';
 import { Pool as PgPool } from 'pg';
-import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
+import getGraphQL from './graphql';
 import { GqlEntityController } from './graphql/controller';
 import { CheckpointsStore } from './stores/checkpoints';
 import { BaseIndexer } from './providers';
@@ -89,24 +87,7 @@ export default class Checkpoint {
   }
 
   public getSchema() {
-    const entityQueryFields = this.entityController.generateQueryFields();
-    const coreQueryFields = this.entityController.generateQueryFields([
-      MetadataGraphQLObject,
-      CheckpointsGraphQLObject
-    ]);
-
-    const query = new GraphQLObjectType({
-      name: 'Query',
-      fields: {
-        ...entityQueryFields,
-        ...coreQueryFields
-      }
-    });
-
-    return addResolversToSchema({
-      schema: new GraphQLSchema({ query }),
-      resolvers: this.entityController.generateEntityResolvers(entityQueryFields)
-    });
+    return this.entityController.generateSchema({ addResolvers: true });
   }
 
   /**

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -13,7 +13,7 @@ import {
 } from 'graphql';
 import pluralize from 'pluralize';
 import { GqlEntityController } from './graphql/controller';
-import { extendSchema, getDerivedFromDirective } from './utils/graphql';
+import { getDerivedFromDirective } from './utils/graphql';
 import { OverridesConfig } from './types';
 
 type TypeInfo = {
@@ -113,13 +113,11 @@ export const getJSType = (
 };
 
 export const codegen = (
-  schema: string,
+  controller: GqlEntityController,
   config: OverridesConfig,
   format: 'typescript' | 'javascript'
 ) => {
   const decimalTypes = config.decimal_types || DEFAULT_DECIMAL_TYPES;
-  const extendedSchema = extendSchema(schema);
-  const controller = new GqlEntityController(extendedSchema, config);
 
   const preamble = `import { Model } from '@snapshot-labs/checkpoint';\n\n`;
 

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -33,6 +33,8 @@ import {
 } from '../utils/graphql';
 import { OverridesConfig } from '../types';
 import { querySingle, queryMulti, getNestedResolver } from './resolvers';
+import { CheckpointsGraphQLObject, MetadataGraphQLObject } from '.';
+import { addResolversToSchema } from '@graphql-tools/schema';
 
 /**
  * Type for single and multiple query resolvers
@@ -561,5 +563,32 @@ export class GqlEntityController {
     }
 
     throw new Error(`sql type for ${type} is not supported`);
+  }
+
+  generateSchema(opts?: { addResolvers?: boolean }) {
+    const entityQueryFields = this.generateQueryFields();
+    const coreQueryFields = this.generateQueryFields([
+      MetadataGraphQLObject,
+      CheckpointsGraphQLObject
+    ]);
+
+    const query = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        ...entityQueryFields,
+        ...coreQueryFields
+      }
+    });
+
+    const schema = new GraphQLSchema({ query });
+
+    if (opts?.addResolvers) {
+      return addResolversToSchema({
+        schema,
+        resolvers: this.generateEntityResolvers(entityQueryFields)
+      });
+    }
+
+    return schema;
   }
 }

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -455,7 +455,7 @@ export class GqlEntityController {
     });
 
     return {
-      type: new GraphQLList(type),
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(type))),
       args: {
         first: {
           type: GraphQLInt

--- a/test/unit/codegen.test.ts
+++ b/test/unit/codegen.test.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectType, buildSchema } from 'graphql';
 import { getInitialValue, getBaseType, getJSType, codegen, getTypeInfo } from '../../src/codegen';
+import { GqlEntityController } from '../../src/graphql/controller';
 import { extendSchema } from '../../src/utils/graphql';
 
 const SCHEMA_SOURCE = `
@@ -172,12 +173,14 @@ describe('getJSType', () => {
 
 describe('codegen', () => {
   const overridesConfig = {};
+  const extendedSchema = extendSchema(SCHEMA_SOURCE);
+  const controller = new GqlEntityController(extendedSchema);
 
   it('should generate typescript code', () => {
-    expect(codegen(SCHEMA_SOURCE, overridesConfig, 'typescript')).toMatchSnapshot();
+    expect(codegen(controller, overridesConfig, 'typescript')).toMatchSnapshot();
   });
 
   it('should generate javascript code', () => {
-    expect(codegen(SCHEMA_SOURCE, overridesConfig, 'javascript')).toMatchSnapshot();
+    expect(codegen(controller, overridesConfig, 'javascript')).toMatchSnapshot();
   });
 });

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -63,6 +63,140 @@ input Vote_filter {
 }"
 `;
 
+exports[`GqlEntityController generateSampleQuery should generate query schema 1`] = `
+"type Query {
+  vote(id: Int!, indexer: String, block: Int): Vote
+  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote]
+  _metadata(id: ID!, indexer: String, block: Int): _Metadata
+  _metadatas(first: Int, skip: Int, orderBy: _Metadata_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Metadata_filter): [_Metadata]
+  _checkpoint(id: ID!, indexer: String, block: Int): _Checkpoint
+  _checkpoints(first: Int, skip: Int, orderBy: _Checkpoint_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Checkpoint_filter): [_Checkpoint]
+}
+
+type Vote {
+  id: Int!
+  name: String
+  authenticators: [String]
+}
+
+enum Vote_orderBy {
+  id
+  name
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+input Vote_filter {
+  id_gt: Int
+  id_gte: Int
+  id_lt: Int
+  id_lte: Int
+  id: Int
+  id_not: Int
+  id_in: [Int]
+  id_not_in: [Int]
+  name_contains: String
+  name_not_contains: String
+  name_contains_nocase: String
+  name_not_contains_nocase: String
+  name: String
+  name_not: String
+  name_in: [String]
+  name_not_in: [String]
+  authenticators: [String]
+  authenticators_not: [String]
+  authenticators_contains: [String]
+  authenticators_not_contains: [String]
+}
+
+"""Core metadata values used internally by Checkpoint"""
+type _Metadata {
+  """example: last_indexed_block"""
+  id: ID!
+  indexer: String!
+  value: String
+}
+
+enum _Metadata_orderBy {
+  id
+  indexer
+  value
+}
+
+input _Metadata_filter {
+  id: ID
+  id_not: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  indexer_contains: String
+  indexer_not_contains: String
+  indexer_contains_nocase: String
+  indexer_not_contains_nocase: String
+  indexer: String
+  indexer_not: String
+  indexer_in: [String]
+  indexer_not_in: [String]
+  value_contains: String
+  value_not_contains: String
+  value_contains_nocase: String
+  value_not_contains_nocase: String
+  value: String
+  value_not: String
+  value_in: [String]
+  value_not_in: [String]
+}
+
+"""Contract and Block where its event is found."""
+type _Checkpoint {
+  """id computed as last 5 bytes of sha256(contract+block)"""
+  id: ID!
+  indexer: String!
+  block_number: Int!
+  contract_address: String!
+}
+
+enum _Checkpoint_orderBy {
+  id
+  indexer
+  block_number
+  contract_address
+}
+
+input _Checkpoint_filter {
+  id: ID
+  id_not: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  indexer_contains: String
+  indexer_not_contains: String
+  indexer_contains_nocase: String
+  indexer_not_contains_nocase: String
+  indexer: String
+  indexer_not: String
+  indexer_in: [String]
+  indexer_not_in: [String]
+  block_number_gt: Int
+  block_number_gte: Int
+  block_number_lt: Int
+  block_number_lte: Int
+  block_number: Int
+  block_number_not: Int
+  block_number_in: [Int]
+  block_number_not_in: [Int]
+  contract_address_contains: String
+  contract_address_not_contains: String
+  contract_address_contains_nocase: String
+  contract_address_not_contains_nocase: String
+  contract_address: String
+  contract_address_not: String
+  contract_address_in: [String]
+  contract_address_not_in: [String]
+}"
+`;
+
 exports[`GqlEntityController generateSampleQuery should return correct query sample for first and only entity 1`] = `
 "
 # Welcome to Checkpoint. Try running the below example query from

--- a/test/unit/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/graphql/__snapshots__/controller.test.ts.snap
@@ -20,7 +20,7 @@ create index \`votes_big_decimal_index\` on \`votes\` (\`big_decimal\`)"
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
   vote(id: Int!, indexer: String, block: Int): Vote
-  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote]
+  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote!]!
 }
 
 type Vote {
@@ -66,11 +66,11 @@ input Vote_filter {
 exports[`GqlEntityController generateSampleQuery should generate query schema 1`] = `
 "type Query {
   vote(id: Int!, indexer: String, block: Int): Vote
-  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote]
+  votes(first: Int, skip: Int, orderBy: Vote_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: Vote_filter): [Vote!]!
   _metadata(id: ID!, indexer: String, block: Int): _Metadata
-  _metadatas(first: Int, skip: Int, orderBy: _Metadata_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Metadata_filter): [_Metadata]
+  _metadatas(first: Int, skip: Int, orderBy: _Metadata_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Metadata_filter): [_Metadata!]!
   _checkpoint(id: ID!, indexer: String, block: Int): _Checkpoint
-  _checkpoints(first: Int, skip: Int, orderBy: _Checkpoint_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Checkpoint_filter): [_Checkpoint]
+  _checkpoints(first: Int, skip: Int, orderBy: _Checkpoint_orderBy, orderDirection: OrderDirection, indexer: String, block: Int, where: _Checkpoint_filter): [_Checkpoint!]!
 }
 
 type Vote {

--- a/test/unit/graphql/controller.test.ts
+++ b/test/unit/graphql/controller.test.ts
@@ -124,5 +124,19 @@ type Venue {
       expect(controller.generateSampleQuery()).not.toBeUndefined();
       expect(controller.generateSampleQuery()).toMatchSnapshot();
     });
+
+    it('should generate query schema', () => {
+      const schema = `
+        type Vote {
+          id: Int!
+          name: String
+          authenticators: [String]
+        }`;
+
+      const controller = new GqlEntityController(schema);
+      const generatedSchema = controller.generateSchema();
+
+      expect(printSchema(generatedSchema)).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Full query schema will be useful for integrating into UI without the need of getting schema from running API instance.

### Test plan

Run `node PATH_TO_CHECKPOINT/dist/src/bin/index.js generate` in API and it should generate `.checkpoint/schema.gql`.