### PR TITLE
fix: unwrap non-null types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.48",
+  "version": "0.1.0-beta.49",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/graphql/controller.ts
+++ b/src/graphql/controller.ts
@@ -163,8 +163,12 @@ export class GqlEntityController {
       entities[obj.name] = this.getTypeFields(obj).reduce((resolvers, field) => {
         const nonNullType = getNonNullType(field.type);
 
-        if (isListType(nonNullType) && nonNullType.ofType instanceof GraphQLObjectType) {
-          resolvers[field.name] = getNestedResolver(multiEntityQueryName(nonNullType.ofType));
+        if (isListType(nonNullType)) {
+          const itemType = getNonNullType(nonNullType.ofType);
+
+          if (itemType instanceof GraphQLObjectType) {
+            resolvers[field.name] = getNestedResolver(multiEntityQueryName(itemType));
+          }
         }
 
         if (nonNullType instanceof GraphQLObjectType) {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -67,8 +67,9 @@ export async function queryMulti(
 ): Promise<Result[]> {
   const { log, knex } = context;
 
-  if (!isListType(info.returnType)) throw new Error('unexpected return type');
-  const returnType = info.returnType.ofType as GraphQLObjectType;
+  const nonNullType = getNonNullType(info.returnType);
+  if (!isListType(nonNullType)) throw new Error('unexpected return type');
+  const returnType = getNonNullType(nonNullType.ofType) as GraphQLObjectType;
   const jsonFields = getJsonFields(returnType);
 
   const tableName = getTableName(returnType.name.toLowerCase());
@@ -299,8 +300,10 @@ export const getNestedResolver =
       indexer: parent._args?.indexer
     };
 
-    const returnType = getNonNullType(info.returnType) as GraphQLList<GraphQLObjectType>;
-    const jsonFields = getJsonFields(returnType.ofType);
+    const returnType = getNonNullType(info.returnType) as
+      | GraphQLList<GraphQLObjectType>
+      | GraphQLList<GraphQLNonNull<GraphQLObjectType>>;
+    const jsonFields = getJsonFields(getNonNullType(returnType.ofType) as GraphQLObjectType);
 
     const parentType = getNonNullType(info.parentType) as GraphQLObjectType;
     const field = parentType.getFields()[info.fieldName];


### PR DESCRIPTION
On SX API we migrated to use non nullable lists in schema, for example [Space!]! but this means we need to unwrap those to get actual type.