### PR TITLE
fix: on reorg only revert reorganized indexer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.49",
+  "version": "0.1.0-beta.50",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/container.ts
+++ b/src/container.ts
@@ -308,11 +308,16 @@ export class Container implements Instance {
 
     await this.knex.transaction(async trx => {
       for (const tableName of tables) {
-        await trx.table(tableName).whereRaw('lower(block_range) > ?', [lastGoodBlock]).delete();
+        await trx
+          .table(tableName)
+          .where('_indexer', this.indexerName)
+          .andWhereRaw('lower(block_range) > ?', [lastGoodBlock])
+          .delete();
 
         await trx
           .table(tableName)
-          .whereRaw('block_range @> int8(??)', [lastGoodBlock])
+          .where('_indexer', this.indexerName)
+          .andWhereRaw('block_range @> int8(??)', [lastGoodBlock])
           .update({
             block_range: this.knex.raw('int8range(lower(block_range), NULL)')
           });

--- a/src/stores/checkpoints.ts
+++ b/src/stores/checkpoints.ts
@@ -209,11 +209,11 @@ export class CheckpointsStore {
     });
   }
 
-  public async getBlockHash(indxer: string, blockNumber: number): Promise<string | null> {
+  public async getBlockHash(indexer: string, blockNumber: number): Promise<string | null> {
     const blocks = await this.knex
       .select(Fields.Blocks.Hash)
       .from(Table.Blocks)
-      .where(Fields.Blocks.Indexer, indxer)
+      .where(Fields.Blocks.Indexer, indexer)
       .where(Fields.Blocks.Number, blockNumber)
       .limit(1);
 


### PR DESCRIPTION
Previously it would try to revert all entries breaking other indexer's state.

It looks like it was the issue that caused state of one indexer to get nuked (some entries being removed, some ending up as empty) sometimes when running multiple indexers.