### PR TITLE
fix: do not catch custom Reorg/NoBlock errors

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -61,19 +61,19 @@ export class EvmProvider extends BaseProvider {
         this.provider.getBlockWithTransactions(blockNum),
         this.getEvents(blockNum)
       ]);
-
-      if (block === null) {
-        this.log.info({ blockNumber: blockNum }, 'block not found');
-        throw new BlockNotFoundError();
-      }
-
-      if (parentHash && block.parentHash !== parentHash) {
-        this.log.error({ blockNumber: blockNum }, 'reorg detected');
-        throw new ReorgDetectedError();
-      }
     } catch (e) {
       this.log.error({ blockNumber: blockNum, err: e }, 'getting block failed... retrying');
       throw e;
+    }
+
+    if (block === null) {
+      this.log.info({ blockNumber: blockNum }, 'block not found');
+      throw new BlockNotFoundError();
+    }
+
+    if (parentHash && block.parentHash !== parentHash) {
+      this.log.error({ blockNumber: blockNum }, 'reorg detected');
+      throw new ReorgDetectedError();
     }
 
     await this.handleBlock(block, eventsMap);

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -69,24 +69,24 @@ export class StarknetProvider extends BaseProvider {
         this.provider.getBlockWithTxs(blockNum),
         this.getEvents(blockNum)
       ]);
-
-      if (parentHash && block.parent_hash !== parentHash) {
-        this.log.error({ blockNumber: blockNum }, 'reorg detected');
-        throw new ReorgDetectedError();
-      }
-
-      if (!isFullBlock(block) || block.block_number !== blockNum) {
-        this.log.error({ blockNumber: blockNum }, 'invalid block');
-        throw new Error('invalid block');
-      }
     } catch (e) {
-      if ((e as Error).message.includes('Block not found') || e instanceof BlockNotFoundError) {
+      if ((e as Error).message.includes('Block not found')) {
         this.log.info({ blockNumber: blockNum }, 'block not found');
         throw new BlockNotFoundError();
       }
 
       this.log.error({ blockNumber: blockNum, err: e }, 'getting block failed... retrying');
       throw e;
+    }
+
+    if (parentHash && block.parent_hash !== parentHash) {
+      this.log.error({ blockNumber: blockNum }, 'reorg detected');
+      throw new ReorgDetectedError();
+    }
+
+    if (!isFullBlock(block) || block.block_number !== blockNum) {
+      this.log.error({ blockNumber: blockNum }, 'invalid block');
+      throw new Error('invalid block');
     }
 
     await this.handleBlock(block, blockEvents);


### PR DESCRIPTION
Previously we threw and cought our own errors immediatelly, in case of EVM Reorg/NoBlock and in case of Starknet Reorg errors would result in getting block failed... retrying log messages.