### PR TITLE
perf: reduce computations related to event hashes and address comparisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -157,10 +157,8 @@ export class EvmProvider extends BaseProvider {
 
     let source: ContractSourceConfig | undefined;
     while ((source = sourcesQueue.shift())) {
-      const contract = getAddress(source.contract);
-
       for (const [eventIndex, log] of logs.entries()) {
-        if (contract === getAddress(log.address)) {
+        if (this.compareAddress(source.contract, log.address)) {
           for (const sourceEvent of source.events) {
             const targetTopic = this.getEventHash(sourceEvent.name);
 
@@ -280,5 +278,9 @@ export class EvmProvider extends BaseProvider {
     }
 
     return this.sourceHashes.get(eventName) as string;
+  }
+
+  compareAddress(a: string, b: string) {
+    return a.toLowerCase() === b.toLowerCase();
   }
 }


### PR DESCRIPTION
This PR will cache computed event hashes for our sources as well as use faster EVM address comparison (that doesn't add checksum as those are bit expensive).