### PR TITLE
feat: allow reverting to preload if fallen behind

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -256,7 +256,7 @@ export class Container implements Instance {
         if (latestBlock > blockNum + BLOCK_PRELOAD_OFFSET * 2) {
           this.log.info(
             { latestBlock, blockNum },
-            `fell behind more than ${BLOCK_PRELOAD_OFFSET * 2} blocks behind, reverting to preload`
+            `fell more than ${BLOCK_PRELOAD_OFFSET * 2} blocks behind, reverting to preload`
           );
 
           this.preloadEndBlock = latestBlock - BLOCK_PRELOAD_OFFSET;


### PR DESCRIPTION
This adds ability to revert to preload if sequential indexing ends up falling behind. We check latest block every 50 blocks and if if it's more than BLOCK_PRELOAD_OFFSET * 2 ahead of us preload will be activated again.

## Test plan
1. Run with SX API.
2. Change ARB1 start block to 312004031.
3. Run it as `ENABLED_NETWORKS=arb1 yarn dev`.
4. You will see it starts with preload, then it switches to sequential indexing.
5. After a while latest block check fires and you get info how behind we are.
6. If we are more than 100 blocks behind you will see message we are reverting to preload.
7. Preloading happens.
8. Now we are going sequential as well with less than 100 blocks behind.