### PR TITLE
fix: handle errors in latest block checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.53",
+  "version": "0.1.0-beta.54",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/container.ts
+++ b/src/container.ts
@@ -249,17 +249,24 @@ export class Container implements Instance {
 
     if (!checkpointBlock && !preloadedBlock) {
       if (blockNum % CHECK_LATEST_BLOCK_INTERVAL === 0) {
-        const latestBlock = await this.indexer.getProvider().getLatestBlockNumber();
+        try {
+          const latestBlock = await this.indexer.getProvider().getLatestBlockNumber();
 
-        this.log.info({ latestBlock, behind: latestBlock - blockNum }, 'checking latest block');
+          this.log.info({ latestBlock, behind: latestBlock - blockNum }, 'checking latest block');
 
-        if (latestBlock > blockNum + BLOCK_PRELOAD_OFFSET * 2) {
-          this.log.info(
-            { latestBlock, blockNum },
-            `fell more than ${BLOCK_PRELOAD_OFFSET * 2} blocks behind, reverting to preload`
+          if (latestBlock > blockNum + BLOCK_PRELOAD_OFFSET * 2) {
+            this.log.info(
+              { latestBlock, blockNum },
+              `fell more than ${BLOCK_PRELOAD_OFFSET * 2} blocks behind, reverting to preload`
+            );
+
+            this.preloadEndBlock = latestBlock - BLOCK_PRELOAD_OFFSET;
+          }
+        } catch (e) {
+          this.log.error(
+            { blockNumber: blockNum, err: e },
+            'error occurred during latest block check, ignoring for now'
           );
-
-          this.preloadEndBlock = latestBlock - BLOCK_PRELOAD_OFFSET;
         }
       }
     }


### PR DESCRIPTION
In case this RPC call fails we need to handle the error. Otherwise it would crash the indexer as it's not handled elsewhere.