### PR TITLE
fix: handle errors in handleReorg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.55",
+  "version": "0.1.0-beta.56",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/container.ts
+++ b/src/container.ts
@@ -321,13 +321,18 @@ export class Container implements Instance {
     let current = blockNumber - 1;
     let lastGoodBlock: null | number = null;
     while (lastGoodBlock === null) {
-      const storedBlockHash = await this.store.getBlockHash(this.indexerName, current);
-      const currentBlockHash = await this.indexer.getProvider().getBlockHash(current);
+      try {
+        const storedBlockHash = await this.store.getBlockHash(this.indexerName, current);
+        const currentBlockHash = await this.indexer.getProvider().getBlockHash(current);
 
-      if (storedBlockHash === null || storedBlockHash === currentBlockHash) {
-        lastGoodBlock = current;
-      } else {
-        current -= 1;
+        if (storedBlockHash === null || storedBlockHash === currentBlockHash) {
+          lastGoodBlock = current;
+        } else {
+          current -= 1;
+        }
+      } catch (e) {
+        this.log.error({ blockNumber: current, err: e }, 'error occurred during block hash check');
+        await sleep(this.config.fetch_interval || DEFAULT_FETCH_INTERVAL);
       }
     }
 


### PR DESCRIPTION
`getBlockHash` can fail so we need to handle this and retry.