### PR TITLE
fix: sort by block_range by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.56",
+  "version": "0.1.0-beta.57",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'graphql';
 import DataLoader from 'dataloader';
 import { ResolverContextInput } from './resolvers';
-import { getTableName, applyQueryFilter, QueryFilter } from '../utils/database';
+import { getTableName, applyQueryFilter, QueryFilter, applyDefaultOrder } from '../utils/database';
 
 /**
  * Creates getLoader function that will return existing, or create a new dataloader
@@ -31,11 +31,14 @@ export const createGetLoader = (context: ResolverContextInput) => {
           .select('*')
           .from(tableName)
           .whereIn(field, ids as string[]);
+
         query = applyQueryFilter(query, tableName, filter);
+        query = applyDefaultOrder(query, tableName);
 
         context.log.debug({ sql: query.toQuery(), ids }, 'executing batched query');
 
         const results = await query;
+
         const resultsMap = results.reduce((acc, result) => {
           if (!acc[result[field]]) acc[result[field]] = [];
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -16,7 +16,7 @@ import {
 import { Knex } from 'knex';
 import { Pool as PgPool } from 'pg';
 import { getNonNullType, getDerivedFromDirective } from '../utils/graphql';
-import { getTableName, applyQueryFilter, QueryFilter } from '../utils/database';
+import { getTableName, applyQueryFilter, QueryFilter, applyDefaultOrder } from '../utils/database';
 import { Logger } from '../utils/logger';
 import type DataLoader from 'dataloader';
 
@@ -204,8 +204,13 @@ export async function queryMulti(
   }
 
   if (args.orderBy) {
-    query = query.orderBy(args.orderBy, args.orderDirection?.toLowerCase() || 'desc');
+    query = query.orderBy(
+      `${tableName}.${args.orderBy}`,
+      args.orderDirection?.toLowerCase() || 'desc'
+    );
   }
+
+  query = applyDefaultOrder(query, tableName);
 
   query = query.limit(args?.first || 1000).offset(args?.skip || 0);
   log.debug({ sql: query.toQuery(), args }, 'executing multi query');

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -37,3 +37,19 @@ export function applyQueryFilter(
 
   return filteredQuery;
 }
+
+/**
+ * Applies the default order to the query.
+ * All entities are by default sorted by block_range in ascending order.
+ * This function is used to ensure that the order is consistent across all queries.
+ * @param query Knex query builder
+ * @param tableName The name of the table to apply the order on
+ * @returns The modified query with the default order applied
+ */
+export function applyDefaultOrder(query: Knex.QueryBuilder, tableName: string) {
+  const isInternalTable = INTERNAL_TABLES.includes(tableName);
+
+  if (isInternalTable) return query;
+
+  return query.orderBy(`${tableName}.block_range`);
+}


### PR DESCRIPTION
This change introduces stable ordering for entities - as last step (after user defined orderBy) entries will be ordered by block_range.

This makes it stable as SQL doesn't make any guarantees about order unless ORDER BY is used.