### PR TITLE
fix: only update latest entry on delete

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.57",
+  "version": "0.1.0-beta.58",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/orm/model.ts
+++ b/src/orm/model.ts
@@ -67,6 +67,7 @@ export default class Model {
       .table(this.tableName)
       .where('id', this.get('id'))
       .andWhere('_indexer', this.indexerName)
+      .andWhereRaw('upper_inf(block_range)')
       .update({
         block_range: register.getKnex().raw('int8range(lower(block_range), ?)', [currentBlock])
       });


### PR DESCRIPTION
When deleting entry we should only update latest entry, otherwise if entity has multiple versions (it was edited) it will update every one of them, so they will end up having the same (id, indexer, block_range) making it non-unique.