### PR TITLE
refactor: improve time complexity of checking for new sources

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -226,9 +226,9 @@ export class EvmProvider extends BaseProvider {
       }
 
       const nextSources = this.instance.getCurrentSources(blockNumber);
-      const newSources = nextSources.filter(
-        nextSource => !lastSources.find(lastSource => lastSource.contract === nextSource.contract)
-      );
+
+      const lastSourcesSet = new Set(lastSources.map(source => source.contract));
+      const newSources = nextSources.filter(nextSource => !lastSourcesSet.has(nextSource.contract));
 
       sourcesQueue = sourcesQueue.concat(newSources);
       lastSources = nextSources;

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -311,9 +311,9 @@ export class StarknetProvider extends BaseProvider {
       }
 
       const nextSources = this.instance.getCurrentSources(blockNumber);
-      const newSources = nextSources.filter(
-        nextSource => !lastSources.find(lastSource => lastSource.contract === nextSource.contract)
-      );
+
+      const lastSourcesSet = new Set(lastSources.map(source => source.contract));
+      const newSources = nextSources.filter(nextSource => !lastSourcesSet.has(nextSource.contract));
 
       sourcesQueue = sourcesQueue.concat(newSources);
       lastSources = nextSources;


### PR DESCRIPTION
Our current implementation was O(n^2) which was already bad enough with 150+ sources (20k+ iterations). As it's executed for every transaction in block it ended up with 5M iterations per block.

Before:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/0bbb55f6-dc4b-4f8f-b8d1-331d9c3b0cd8" />
<img width="692" alt="image" src="https://github.com/user-attachments/assets/6210c566-8a12-465b-a4a7-d8c95a6ecce4" />

After:
(testing...)