### PR TITLE
refactor: remove recursive call when processing blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -81,7 +81,7 @@ export class BaseProvider {
     throw new Error(`processBlock method was not defined when fetching block ${blockNum}`);
   }
 
-  processPool(blockNumber: number) {
+  processPool(blockNumber: number): Promise<void> {
     throw new Error(
       `processPool method was not defined when fetching pool for block ${blockNumber}`
     );


### PR DESCRIPTION
Recursive calls (without termination like we did before) can lead to exceeding maximum call stack size. Instead we use loop.

This will additionally reduce memory usage as stack won't grow indefinitely.

## Test plan

1. Use it as normal, it works as expected. I tested it by syncing up `sep` and `sn-sep` on SX-API and it worked as expected.