### PR TITLE
refactor: remove broken deployFn

### DIFF
--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -206,7 +206,7 @@ export class EvmProvider extends BaseProvider {
                   parsedEvent = iface.parseLog(log);
                 } catch (err) {
                   this.log.warn(
-                    { contract: source.contract, txType: tx.type, handlerFn: source.deploy_fn },
+                    { contract: source.contract, txType: tx.type, handlerFn: sourceEvent.fn },
                     'failed to parse event'
                   );
                 }

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -11,7 +11,6 @@ import {
   EventsMap,
   ParsedEvent,
   isFullBlock,
-  isDeployTransaction,
   Writer
 } from './types';
 import { ContractSourceConfig } from '../../types';
@@ -240,27 +239,6 @@ export class StarknetProvider extends BaseProvider {
       let foundContractData = false;
       const contract = validateAndParseAddress(source.contract);
 
-      if (
-        isDeployTransaction(tx) &&
-        source.deploy_fn &&
-        contract === validateAndParseAddress(tx.contract_address)
-      ) {
-        this.log.info(
-          { contract: source.contract, txType: tx.type, handlerFn: source.deploy_fn },
-          'found deployment transaction'
-        );
-
-        await this.writers[source.deploy_fn]({
-          source,
-          block,
-          blockNumber,
-          tx,
-          helpers
-        });
-
-        wasTransactionProcessed = true;
-      }
-
       for (const [eventIndex, event] of events.entries()) {
         if (contract === validateAndParseAddress(event.from_address)) {
           for (const sourceEvent of source.events) {
@@ -277,7 +255,7 @@ export class StarknetProvider extends BaseProvider {
                   parsedEvent = parseEvent(this.abis[source.abi], event);
                 } catch (err) {
                   this.log.warn(
-                    { contract: source.contract, txType: tx.type, handlerFn: source.deploy_fn },
+                    { contract: source.contract, txType: tx.type, handlerFn: sourceEvent.fn },
                     'failed to parse event'
                   );
                 }

--- a/src/providers/starknet/types.ts
+++ b/src/providers/starknet/types.ts
@@ -26,7 +26,3 @@ export type Writer = (
 export function isFullBlock(block: Block): block is FullBlock {
   return 'block_number' in block;
 }
-
-export function isDeployTransaction(tx: Transaction | PendingTransaction): tx is DeployTransaction {
-  return tx.type === 'DEPLOY';
-}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -9,7 +9,6 @@ export const contractSourceConfigSchema = z.object({
   contract: z.string(),
   abi: z.string().optional(),
   start: z.number().gte(0),
-  deploy_fn: z.string().optional(),
   events: z.array(contractEventConfigSchema)
 });
 

--- a/test/fixtures/checkpointConfig.fixture.ts
+++ b/test/fixtures/checkpointConfig.fixture.ts
@@ -4,7 +4,6 @@ export const validCheckpointConfig = {
     {
       contract: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
       start: 112319,
-      deploy_fn: 'handleDeploy',
       events: [
         {
           name: 'proposal_created',


### PR DESCRIPTION
deploy_fn only works for DEPLOY transactions on Starknet, which are not used for long time (Universal Deployer Contract is used nowadays).

EVM didn't support deploy_fn at all.

To avoid confusing and clean up code this commit removes deploy_fn from codebase.