### PR TITLE
fix: fetch missing logs if new source is added

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -111,7 +111,6 @@ export class Container implements Instance {
 
     this.config.sources.push(source);
     this.cpBlocksCache = [];
-    this.indexer.getProvider().handleNewSourceAdded();
   }
 
   public async executeTemplate(

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -93,10 +93,6 @@ export class BaseProvider {
       `getCheckpointsRange method was not defined when fetching events from ${fromBlock} to ${toBlock}`
     );
   }
-
-  handleNewSourceAdded() {
-    throw new Error('handleNewSourceAdded method was not defined');
-  }
 }
 
 export class BaseIndexer {

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -160,7 +160,7 @@ export class EvmProvider extends BaseProvider {
         return handlers;
       }, {});
 
-      for (const [eventIndex, event] of logs.entries()) {
+      for (const event of logs) {
         const handler = globalEventHandlers[event.topics[0]];
         if (!handler) continue;
 
@@ -174,7 +174,6 @@ export class EvmProvider extends BaseProvider {
           blockNumber,
           txId,
           rawEvent: event,
-          eventIndex,
           helpers
         });
       }
@@ -186,7 +185,7 @@ export class EvmProvider extends BaseProvider {
     let source: ContractSourceConfig | undefined;
     while ((source = sourcesQueue.shift())) {
       let foundContractData = false;
-      for (const [eventIndex, log] of logs.entries()) {
+      for (const log of logs) {
         if (this.compareAddress(source.contract, log.address)) {
           for (const sourceEvent of source.events) {
             const targetTopic = this.getEventHash(sourceEvent.name);
@@ -218,7 +217,6 @@ export class EvmProvider extends BaseProvider {
                 txId,
                 rawEvent: log,
                 event: parsedEvent,
-                eventIndex,
                 helpers
               });
             }

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -232,8 +232,14 @@ export class EvmProvider extends BaseProvider {
         ]);
 
         const nextSources = this.instance.getCurrentSources(blockNumber);
+        const hasNewSources = nextSources.length > lastSources.length;
+
         sourcesQueue = sourcesQueue.concat(nextSources.slice(lastSources.length));
         lastSources = this.instance.getCurrentSources(blockNumber);
+
+        if (hasNewSources) {
+          this.handleNewSourceAdded();
+        }
       }
     }
 

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -130,21 +130,15 @@ export class EvmProvider extends BaseProvider {
 
     const blockTransactions = Object.keys(eventsMap);
 
-    for (const [i, txId] of blockTransactions.entries()) {
-      await this.handleTx(block, blockNumber, i, txId, eventsMap[txId] || []);
+    for (const txId of blockTransactions) {
+      await this.handleTx(block, blockNumber, txId, eventsMap[txId] || []);
     }
 
     this.log.debug({ blockNumber }, 'handling block done');
   }
 
-  private async handleTx(
-    block: Block | null,
-    blockNumber: number,
-    txIndex: number,
-    txId: string,
-    logs: Log[]
-  ) {
-    this.log.debug({ txIndex }, 'handling transaction');
+  private async handleTx(block: Block | null, blockNumber: number, txId: string, logs: Log[]) {
+    this.log.debug({ txId }, 'handling transaction');
 
     const helpers = await this.instance.getWriterHelpers();
 
@@ -243,7 +237,7 @@ export class EvmProvider extends BaseProvider {
       }
     }
 
-    this.log.debug({ txIndex }, 'handling transaction done');
+    this.log.debug({ txId }, 'handling transaction done');
   }
 
   private async getEvents({

--- a/src/providers/evm/provider.ts
+++ b/src/providers/evm/provider.ts
@@ -35,7 +35,6 @@ export class EvmProvider extends BaseProvider {
    */
   private readonly formatter = new Formatter();
   private readonly writers: Record<string, Writer>;
-  private processedPoolTransactions = new Set();
   private startupLatestBlockNumber: number | undefined;
   private sourceHashes = new Map<string, string>();
   private logsCache = new Map<number, Log[]>();
@@ -130,13 +129,10 @@ export class EvmProvider extends BaseProvider {
     this.log.info({ blockNumber }, 'handling block');
 
     const blockTransactions = Object.keys(eventsMap);
-    const txsToCheck = blockTransactions.filter(txId => !this.processedPoolTransactions.has(txId));
 
-    for (const [i, txId] of txsToCheck.entries()) {
+    for (const [i, txId] of blockTransactions.entries()) {
       await this.handleTx(block, blockNumber, i, txId, eventsMap[txId] || []);
     }
-
-    this.processedPoolTransactions.clear();
 
     this.log.debug({ blockNumber }, 'handling block done');
   }

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -124,14 +124,14 @@ export class StarknetProvider extends BaseProvider {
     await this.handlePool(txIds, eventsMap, blockNumber);
   }
 
-  private async handleBlock(blockNumber, block: FullBlock | null, eventsMap: EventsMap) {
+  private async handleBlock(blockNumber: number, block: FullBlock | null, eventsMap: EventsMap) {
     this.log.info({ blockNumber }, 'handling block');
 
     const blockTransactions = Object.keys(eventsMap);
     const txsToCheck = blockTransactions.filter(txId => !this.seenPoolTransactions.has(txId));
 
-    for (const [i, txId] of txsToCheck.entries()) {
-      await this.handleTx(block, blockNumber, i, txId, eventsMap[txId] || []);
+    for (const txId of txsToCheck) {
+      await this.handleTx(block, blockNumber, txId, eventsMap[txId] || []);
     }
 
     this.seenPoolTransactions.clear();
@@ -142,8 +142,8 @@ export class StarknetProvider extends BaseProvider {
   private async handlePool(txIds: string[], eventsMap: EventsMap, blockNumber: number) {
     this.log.info('handling pool');
 
-    for (const [i, txId] of txIds.entries()) {
-      await this.handleTx(null, blockNumber, i, txId, eventsMap[txId] || []);
+    for (const txId of txIds) {
+      await this.handleTx(null, blockNumber, txId, eventsMap[txId] || []);
 
       this.seenPoolTransactions.add(txId);
     }
@@ -154,11 +154,10 @@ export class StarknetProvider extends BaseProvider {
   private async handleTx(
     block: FullBlock | null,
     blockNumber: number,
-    txIndex: number,
     txId: string,
     events: Event[]
   ) {
-    this.log.debug({ txIndex }, 'handling transaction');
+    this.log.debug({ txId }, 'handling transaction');
 
     if (this.processedTransactions.has(txId)) {
       this.log.warn({ hash: txId }, 'transaction already processed');
@@ -272,7 +271,7 @@ export class StarknetProvider extends BaseProvider {
       }
     }
 
-    this.log.debug({ txIndex }, 'handling transaction done');
+    this.log.debug({ txId }, 'handling transaction done');
   }
 
   private async getBlockWithReceipts(blockId: SPEC.BLOCK_ID) {

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -187,7 +187,7 @@ export class StarknetProvider extends BaseProvider {
         return handlers;
       }, {});
 
-      for (const [eventIndex, event] of events.entries()) {
+      for (const event of events) {
         const handler = globalEventHandlers[event.keys[0]];
         if (!handler) continue;
 
@@ -201,7 +201,6 @@ export class StarknetProvider extends BaseProvider {
           blockNumber,
           txId,
           rawEvent: event,
-          eventIndex,
           helpers
         });
 
@@ -217,7 +216,7 @@ export class StarknetProvider extends BaseProvider {
       let foundContractData = false;
       const contract = validateAndParseAddress(source.contract);
 
-      for (const [eventIndex, event] of events.entries()) {
+      for (const event of events) {
         if (contract === validateAndParseAddress(event.from_address)) {
           for (const sourceEvent of source.events) {
             if (this.getEventHash(sourceEvent.name) === event.keys[0]) {
@@ -246,7 +245,6 @@ export class StarknetProvider extends BaseProvider {
                 txId,
                 rawEvent: event,
                 event: parsedEvent,
-                eventIndex,
                 helpers
               });
 

--- a/src/providers/starknet/provider.ts
+++ b/src/providers/starknet/provider.ts
@@ -266,8 +266,14 @@ export class StarknetProvider extends BaseProvider {
         ]);
 
         const nextSources = this.instance.getCurrentSources(blockNumber);
+        const hasNewSources = nextSources.length > lastSources.length;
+
         sourcesQueue = sourcesQueue.concat(nextSources.slice(lastSources.length));
         lastSources = this.instance.getCurrentSources(blockNumber);
+
+        if (hasNewSources) {
+          this.handleNewSourceAdded();
+        }
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,6 @@ export type OverridesConfig = z.infer<typeof overridesConfigSchema>;
 
 export type BaseWriterParams = {
   blockNumber: number;
-  eventIndex?: number;
   source?: ContractSourceConfig;
   helpers: ReturnType<Instance['getWriterHelpers']>;
 };


### PR DESCRIPTION
Currently we don't handle a case where we process block/tx and new
events should be handled (due to new source being added).

This PR fixes it by fetching missing logs/events.