### PR TITLE
fix: only refetch missing events if block comes from preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/checkpoint",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "license": "MIT",
   "bin": {
     "checkpoint": "dist/src/bin/index.js"

--- a/src/providers/evm/types.ts
+++ b/src/providers/evm/types.ts
@@ -2,6 +2,16 @@ import { Provider, Log } from '@ethersproject/providers';
 import { LogDescription } from '@ethersproject/abi';
 import { BaseWriterParams } from '../../types';
 
+export type EventsData = {
+  /**
+   * Whether the events were preloaded from the cache.
+   * If true, it means that events were fetched only for known sources and it might not contain all events from the block.
+   * In that case additional logs fetching will be performed for new sources.
+   */
+  isPreloaded: boolean;
+  events: Record<string, Log[]>;
+};
+
 export type Block = Awaited<ReturnType<Provider['getBlock']>>;
 
 export type Writer = (

--- a/src/providers/starknet/types.ts
+++ b/src/providers/starknet/types.ts
@@ -9,7 +9,16 @@ export type Event = RPC.GetEventsResponse['events'][number];
 // (Partially) narrowed types as real types are not exported from `starknet`.
 export type FullBlock = Block & { block_number: number; block_hash: string };
 
-export type EventsMap = { [key: string]: Event[] };
+export type EventsData = {
+  /**
+   * Whether the events were preloaded from the cache.
+   * If true, it means that events were fetched only for known sources and it might not contain all events from the block.
+   * In that case additional logs fetching will be performed for new sources.
+   */
+  isPreloaded: boolean;
+  events: Record<string, Event[]>;
+};
+
 export type ParsedEvent = Record<string, any>;
 
 export type Writer = (


### PR DESCRIPTION
If event don't come from preload it means we have every event from it, meaning twe don't need to fetch missing ones.

### Test plan

1. Run sx-api with this version starting with latest block on sepolia.
2. Create space on Ethereum Sepolia.
3. Space gets indexed properly (previously it would get stuck there).