### PR TITLE
fix: validate block range hint

### DIFF
--- a/src/providers/evm/helpers.test.ts
+++ b/src/providers/evm/helpers.test.ts
@@ -1,0 +1,86 @@
+import { getRangeHint } from './helpers';
+import { CustomJsonRpcError } from './types';
+
+describe('getRangeHint', () => {
+  it('should return null on unknown errors', () => {
+    const genericError = new Error('Generic error');
+
+    const range = getRangeHint(genericError, {
+      from: 1000,
+      to: 2000
+    });
+
+    expect(range).toBe(null);
+  });
+
+  it('should return null on unknown errors', () => {
+    const unknownError = new CustomJsonRpcError('Unknown error', -99999, { some: 'data' });
+
+    expect(
+      getRangeHint(unknownError, {
+        from: 1000,
+        to: 2000
+      })
+    ).toBe(null);
+  });
+
+  describe('Infura error (code: -32005)', () => {
+    it('should return range from error data', () => {
+      const infuraError = new CustomJsonRpcError('Block range too large', -32005, {
+        from: '0x3e8',
+        to: '0x4cf'
+      });
+
+      const result = getRangeHint(infuraError, {
+        from: 1000,
+        to: 2000
+      });
+
+      expect(result).toEqual({
+        from: 1000,
+        to: 1231
+      });
+    });
+
+    it('should not return range if data is invalid', () => {
+      const infuraError = new CustomJsonRpcError('Block range too large', -32005, {});
+
+      const result = getRangeHint(infuraError, {
+        from: 1000,
+        to: 2000
+      });
+
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe('Ankr error (code: -32062)', () => {
+    it('should return half the current range', () => {
+      const ankrError = new CustomJsonRpcError('Block range is too large', -32062, {});
+
+      const result = getRangeHint(ankrError, {
+        from: 1000,
+        to: 2000
+      });
+
+      expect(result).toEqual({
+        from: 1000,
+        to: 1500
+      });
+    });
+
+    it('should round up', () => {
+      const ankrError = new CustomJsonRpcError('Block range is too large', -32062, {});
+
+      const result = getRangeHint(ankrError, {
+        from: 1000,
+        to: 1501
+      });
+
+      expect(result).toEqual({
+        from: 1000,
+        to: 1251
+      });
+    });
+  });
+});

--- a/src/providers/evm/helpers.ts
+++ b/src/providers/evm/helpers.ts
@@ -1,0 +1,38 @@
+import { CustomJsonRpcError } from './types';
+
+type Range = {
+  from: number;
+  to: number;
+};
+
+export function getRangeHint(err: unknown, currentRange: Range): Range | null {
+  if (!(err instanceof CustomJsonRpcError)) {
+    return null;
+  }
+
+  // Infura (code: -32005)
+  if (err.code === -32005 && err.data.from && err.data.from) {
+    const from = parseInt(err.data.from, 16);
+    const to = parseInt(err.data.to, 16);
+
+    if (isFinite(from) && isFinite(to)) {
+      return {
+        from,
+        to
+      };
+    }
+
+    return null;
+  }
+
+  // Ankr (code: -32062): Block range is too large
+  if (err.code === -32062) {
+    // We have no range in the error data, so we return the current range, but half as long
+    return {
+      from: currentRange.from,
+      to: currentRange.from + Math.ceil((currentRange.to - currentRange.from) / 2)
+    };
+  }
+
+  return null;
+}

--- a/src/providers/evm/types.ts
+++ b/src/providers/evm/types.ts
@@ -2,6 +2,12 @@ import { Provider, Log } from '@ethersproject/providers';
 import { LogDescription } from '@ethersproject/abi';
 import { BaseWriterParams } from '../../types';
 
+export class CustomJsonRpcError extends Error {
+  constructor(message: string, public code: number, public data: any) {
+    super(message);
+  }
+}
+
 export type EventsData = {
   /**
    * Whether the events were preloaded from the cache.


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/workflow/issues/639

We had case of RPC using Infura-like range hint, but from/to were either missing or not using hex format which resulted in our code setting itself to NaN.

Now we validate those values are finite.

We also include new Ankr size hint.